### PR TITLE
add LFNW 2016 presentation and clean up whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,26 +64,28 @@
         <ul class="post-list">
 
           <li>
-            <h5 class="title"><a href="https://qconlondon.com/system/files/presentation-slides/sylvanclebsch.pdf" rel="bookmark">'Pony for Fintech' - slides from QCon London presentation</a></h5>
+            <h5 class="title"><a href="https://www.linuxfestnorthwest.org/2016/sessions/pony-language-provably-safe-lockless-concurrency" rel="bookmark">'Pony - A Language for Provably Safe Lockless Concurrency' - video from LinuxFest Northwest 2016</a></h5>
           </li>
 
+          <li>
+            <h5 class="title"><a href="https://qconlondon.com/system/files/presentation-slides/sylvanclebsch.pdf" rel="bookmark">'Pony for Fintech' - slides from QCon London presentation</a></h5>
+          </li>
 
           <li>
             <h5 class="title"><a href="http://www.infoq.com/news/2016/03/pony-fintech" rel="bookmark">'Using the Actor-model Language Pony for FinTech' at InfoQ</a></h5>
           </li>
 
-            <li>
-              <h5 class="title"><a href="http://blog.acolyer.org/2016/02/17/deny-capabilities" rel="bookmark">'Deny Capabilities for Safe, Fast Actors' at the Morning Paper</a></h5>
-            </li>
+          <li>
+            <h5 class="title"><a href="http://blog.acolyer.org/2016/02/17/deny-capabilities" rel="bookmark">'Deny Capabilities for Safe, Fast Actors' at the Morning Paper</a></h5>
+          </li>
 
-            <li>
-              <h5 class="title"><a href="http://blog.acolyer.org/2016/02/18/ownership-and-reference-counting-based-garbage-collection-in-the-actor-world" rel="bookmark">'Ownership and Reference Counting Based Garbage Collection in the Actor World' at the Morning Paper</a></h5>
-            </li>
+          <li>
+            <h5 class="title"><a href="http://blog.acolyer.org/2016/02/18/ownership-and-reference-counting-based-garbage-collection-in-the-actor-world" rel="bookmark">'Ownership and Reference Counting Based Garbage Collection in the Actor World' at the Morning Paper</a></h5>
+          </li>
 
           <li>
             <h5 class="title"><a href="http://www.infoq.com/interviews/clebsch-pony" rel="bookmark">Video: Pony designer Sylvan Clebsch on the Actor-Model Language Pony, Garbage Collection, Capabilities, Concurrency at InfoQ</a></h5>
           </li>
-
 
           <li>
             <h5 class="title"><a href="https://cdn.rawgit.com/darach/my_little_pony/master/my-little-pony.html#" rel="bookmark">November 4: Presentation slides for "My Little Pony" talk at CodeMesh 2015 in London</a></h5>


### PR DESCRIPTION
I didn't delete a link, the git diff just looks weird.