### PR TITLE
Add a link to the standard library on the main page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
         <p>
           <div class="inlineblock"><a class="jumbobtn btn btn-lg btn-success" href="https://github.com/ponylang/ponyc" role="button">Github</a></div>
           <div class="inlineblock"><a class="jumbobtn btn btn-lg btn-success" href="http://tutorial.ponylang.org/" role="button">Tutorial</a></div>
+          <div class="inlineblock"><a class="jumbobtn btn btn-lg btn-success" href="http://www.ponylang.org/ponyc/" role="button">Standard Library</a></div>
           <div class="inlineblock"><a class="jumbobtn btn btn-lg btn-success" href="https://groups.io/g/pony+user" role="button">Mailing list</a></div>
         </p>
       </div>


### PR DESCRIPTION
Adding the link creates a minor flow problem with the green button boxes. On resizing the window to narrower, the flow problem resolves itself; tested: Chrome 51.0.2704.79, Firefox 46.0.1