### PR TITLE
Fix home page jumbotron button spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,7 +47,8 @@ body {
 }
 
 .inlineblock {
-  display: inline;
+  display: inline-block;
+  padding: 2px 0;
 }
 
 .marketing {


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/379404/16787876/d5d90896-486d-11e6-897c-f141e461be5f.png)

After:
![image](https://cloud.githubusercontent.com/assets/379404/16787888/fa6285b6-486d-11e6-901d-98fc020a7073.png)
