### PR TITLE
Updated HTML structure to fix overly narrow container on medium viewport

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,43 +29,67 @@
             </p>
         </div>
 
-        <div class="col-md-3 col-lg-12">
-            <!--
-            <h4>Upcoming talks</h4>
-            <ul class="post-list">
-                <li>
-                    <h5 class="title">
-                        <a href="https://qconlondon.com/presentation/using-pony-fintech" rel="bookmark">
-                        'Using Pony for Fintech' at Qcon London 2016
-                        </a> on <a href="https://qconlondon.com/london-2016/schedule">Wed, 9 March, 1.40pm</a>
-                    </h5>
-                </li>
-            </ul>
-            -->
-
-            <h4>Recent talks and articles</h4>
-            <ul class="post-list">
-                {{ $data := getJSON "data/recent-talks.json" }}
-                {{ range $data.items }}
-                    {{ $item := . }}
+        <div class="recent-talks row">
+            <div class="col-lg-12">
+                <!--
+                <h4>Upcoming talks</h4>
+                <ul class="post-list">
                     <li>
-                        <h5 class="title"><a href="{{ $item.href }}" rel="bookmark">{{ $item.title }}</a></h5>
+                        <h5 class="title">
+                            <a href="https://qconlondon.com/presentation/using-pony-fintech" rel="bookmark">
+                            'Using Pony for Fintech' at Qcon London 2016
+                            </a> on <a href="https://qconlondon.com/london-2016/schedule">Wed, 9 March, 1.40pm</a>
+                        </h5>
                     </li>
-                {{ end }}
-            </ul>
+                </ul>
+                -->
 
-            <h4>Community</h4>
-            <p align="justify">Check out <a href="https://groups.io/g/pony" rel="bookmark">the main Pony group</a> for announcements, help, user groups, and more.</p>
+                <h4>Recent talks and articles</h4>
+                <ul class="post-list">
+                    {{ $data := getJSON "data/recent-talks.json" }}
+                    {{ range $data.items }}
+                        {{ $item := . }}
+                        <li>
+                            <h5 class="title"><a href="{{ $item.href }}" rel="bookmark">{{ $item.title }}</a></h5>
+                        </li>
+                    {{ end }}
+                </ul>
+            </div>
+        </div>
 
-            <h4>Research</h4>
-            <p align="justify">We have published a <a href="https://github.com/ponylang/ponylang.github.io/tree/master/media/papers">collection of papers</a>.</p>
+        <div class="community row">
+            <div class="col-lg-12">
+                <h4>Community</h4>
+                <p align="justify">Check out <a href="https://groups.io/g/pony" rel="bookmark">the main Pony group</a> for announcements, help, user groups, and more.</p>
+            </div>
+        </div>
 
-            <h4>News</h4>
-            <p align="justify">Follow us <a href="https://twitter.com/ponylang">on Twitter @ponylang</a>.</p>
+        <div class="research row">
+            <div class="col-lg-12">
+                <h4>Research</h4>
+                <p align="justify">We have published a <a href="https://github.com/ponylang/ponylang.github.io/tree/master/media/papers">collection of papers</a>.</p>
+            </div>
+        </div>
 
-            <img src="/media/img/ipr0gram-1.jpg" width="49%">
-            <img src="/media/img/ipr0gram-2.jpg" width="49%">
-            <p align="center"><i>The audience for "Actor-based programming in Pony" at Imperial College London, October 2015</i></p>
+        <div class="news row">
+            <div class="col-lg-12">
+                <h4>News</h4>
+                <p align="justify">Follow us <a href="https://twitter.com/ponylang">on Twitter @ponylang</a>.</p>
+            </div>
+        </div>
+
+        <div class="photos row">
+            <div class="photo col-xs-12 col-sm-6">
+                <img src="/media/img/ipr0gram-1.jpg" class="img img-responsive img-thumbnail">
+            </div>
+
+            <div class="photo col-xs-12 col-sm-6">
+                <img src="/media/img/ipr0gram-2.jpg" class="img img-responsive img-thumbnail">
+            </div>
+
+            <div class="caption col-lg-12">
+                <p align="center"><i>The audience for "Actor-based programming in Pony" at Imperial College London, October 2015</i></p>
+            </div>
         </div>
     </div>
 

--- a/static/static/css/style.css
+++ b/static/static/css/style.css
@@ -22,9 +22,13 @@ body {
 }
 
 .footer {
-  padding-top: 19px;
-  color: #777;
   border-top: 1px solid #e5e5e5;
+  color: #777;
+  margin-top: 40px;
+  padding-top: 20px;
+}
+.footer p {
+  margin: 0;
 }
 
 @media (min-width: 768px) {
@@ -73,14 +77,24 @@ body {
   }
 }
 
+/* --------------------------------------------------------------------------------
+ * Photos
+ * -------------------------------------------------------------------------------- */
+.photos .photo {
+  margin-bottom: 20px;
+}
+
+/* --------------------------------------------------------------------------------
+ * GitHub Ribbon
+ * -------------------------------------------------------------------------------- */
 .ribbon {
   background-color: #a00;
   overflow: hidden;
   white-space: nowrap;
   /* top left corner */
   position: fixed;
-  left: -50px;
-  top: 40px;
+    left: -45px;
+    top: 40px;
   /* 45 deg ccw rotation */
   -webkit-transform: rotate(-45deg);
      -moz-transform: rotate(-45deg);
@@ -91,16 +105,23 @@ body {
   -webkit-box-shadow: 0 0 10px #888;
      -moz-box-shadow: 0 0 10px #888;
           box-shadow: 0 0 10px #888;
+  z-index: 9;
 }
 .ribbon a {
   border: 1px solid #faa;
   color: #fff;
   display: block;
   font: bold 81.25% 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  margin: 1px 0;
   padding: 10px 50px;
   text-align: center;
   text-decoration: none;
   /* shadow */
   text-shadow: 0 0 5px #444;
+}
+
+@media screen and (max-width: 767px) {
+  .ribbon {
+    left: -50px;
+    top: 30px;
+  }
 }


### PR DESCRIPTION
The Recent Talks section currently converts to an overly narrow column
on medium viewport width (from 12 columns to around 3 columns). This change
enforce some structure (`container -> row -> col`) to introduce a fix and make
it easier to understand how styles affects child elements.

In addition:
- Added some more whitespace between body and footer
- Small positioning tweak for the GitHub ribbon