### PR TITLE
Blog: Removes tags and re-styles date/posted link

### DIFF
--- a/content/blog/0.12.0-released.md
+++ b/content/blog/0.12.0-released.md
@@ -13,8 +13,6 @@ The release also features a breaking change in the form of [PR #1741](https://gi
 
 Enjoy!
 
-## [0.12.0] - 2017-03-29
-
 ### Fixed
 
 - Don't ignore buffer length when printing ([PR #1768](https://github.com/ponylang/ponyc/pull/1768))

--- a/content/blog/0.12.1-released.md
+++ b/content/blog/0.12.1-released.md
@@ -9,8 +9,6 @@ draft = false
 This is a recommended update; 0.12.0 broke ponytest. No tests will run using 0.12.0. Upgrading to 0.12.1 immediately is advised.
 <!--more-->
 
-## [0.12.1] - 2017-03-29
-
 ### Fixed
 
 - Bug in ponytest resulted in all tests being skipped (PR #1778)

--- a/content/blog/0.12.2-released.md
+++ b/content/blog/0.12.2-released.md
@@ -10,8 +10,6 @@ Thanks to Gordon Tisher for finding the cause of our extreme busy wait problem o
 
 Windows, Debian and RedHat packages are available via Bintray. OSX via Homebrew should be coming soon.
 
-## [0.12.2] - 2017-03-30
-
 ### Fixed
 
 - Fix extreme CPU use in scheduler on Windows (PR #1785)

--- a/content/blog/0.12.3-released.md
+++ b/content/blog/0.12.3-released.md
@@ -10,9 +10,7 @@ title: 0.12.3 released
 If you aren't running Pony on Windows, you can ignore this version and stick with 0.12.2. Windows users are advised to upgrade as soon as possible if they are experiencing problems building binaries with the Pony compiler.
 <!--more-->
 
-Prior to [PR #1794](https://github.com/ponylang/ponyc/pull/1794), `ponyc` would only look for a linker from the version of Visual Studio with which it was compiled, and only looked at one registry key for install information. A recent change ([44b2d56](https://github.com/ponylang/ponyc/commit/44b2d56c5618142fe0fd628eeadbd5975157d62f)) broke support for Visual Build Tools C++ 2015. 
-
-## [0.12.3] - 2017-04-01
+Prior to [PR #1794](https://github.com/ponylang/ponyc/pull/1794), `ponyc` would only look for a linker from the version of Visual Studio with which it was compiled, and only looked at one registry key for install information. A recent change ([44b2d56](https://github.com/ponylang/ponyc/commit/44b2d56c5618142fe0fd628eeadbd5975157d62f)) broke support for Visual Build Tools C++ 2015.
 
 ### Fixed
 

--- a/content/community/planet-pony.md
+++ b/content/community/planet-pony.md
@@ -1,7 +1,7 @@
 +++
 title = "Planet Pony"
 +++
-We don't have a Pony blog aggregator at the moment, so in the meantime, we have this manually edited stand in. It's like the [early curated days of Yahoo!](https://www.youtube.com/watch?v=TRAl48Ucgmw) 
+We don't have a Pony blog aggregator at the moment, so in the meantime, we have this manually edited stand in. It's like the [early curated days of Yahoo!](https://www.youtube.com/watch?v=TRAl48Ucgmw)
 
 ## 2017
 
@@ -33,7 +33,7 @@ We don't have a Pony blog aggregator at the moment, so in the meantime, we have 
 * [the morning paper: Ownership and Reference Counting Based Garbage Collection in the Actor World](http://blog.acolyer.org/2016/02/18/ownership-and-reference-counting-based-garbage-collection-in-the-actor-world/)
 * [the morning paper: Deny Capabilities for Safe, Fast Actors](http://blog.acolyer.org/2016/02/17/deny-capabilities/)
 
-## 2015 
+## 2015
 
 * [Pony designer Sylvan Clebsch on the Actor-Model Language Pony, Garbage Collection, Capabilities, Concurrency](http://www.infoq.com/interviews/clebsch-pony)
 * [Inside the Pony TCP Stack](http://www.monkeysnatchbanana.com/2015/12/19/inside-the-pony-tcp-stack/)

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -26,17 +26,20 @@
     <div class="wrapper">
       <h1>{{ .Title }}</h1>
       {{ if .Params.subtitle }}<p class="subtitle">{{ .Params.subtitle }}</p>{{ end }}
-      <p>
         {{ if .Params.categories }}
-          Posted in
-          {{ $ncats := sub (len .Params.categories) 1}}
-          {{ range $index, $tag := .Params.categories }}
-            {{ $url := printf "categories/%s" ( . | urlize) }}
-            <a href="{{ $url | absURL }}">{{ . }}</a>{{if ne $index $ncats }}, {{ end }}
-          {{ end }}<br/>
+      <section class="blog-meta">
+        <h4>
+          <strong>{{ .Date.Format "Monday, January 02, 2006" }}</strong> |
+        Posted in
+        {{ $ncats := sub (len .Params.categories) 1}}
+        {{ range $index, $tag := .Params.categories }}
+        {{ $url := printf "categories/%s" ( . | urlize) }}
+        <a href="{{ $url | absURL }}">{{ . }}</a>{{if ne $index $ncats }}, {{ end }}
         {{ end }}
-        {{ .Date.Format "Monday, January 02, 2006" }}
-      </p>
+        {{ end }}
+        </h4>
+      </section>
+
 
   {{ .Content }}
 

--- a/static/stylesheets/pony-material.css
+++ b/static/stylesheets/pony-material.css
@@ -15,6 +15,12 @@
   font-size: 18px;
 }
 
+section.blog-meta  h4 {
+  font-size: 16px;
+  font-style: normal;
+  color: #757575;
+}
+
 dl {
   margin-top: 32px;
 }


### PR DESCRIPTION
- Remove tags from posts - redundant
- Wraps date/posted in in a new section .blog-meta
- Re-styles contents of .blog-meta

![screenshot 2017-04-04 08 41 59](https://cloud.githubusercontent.com/assets/215030/24657173/45b18438-1913-11e7-94be-63a4d7928a91.png)
