### PR TITLE
Fix partially broken Netlify previews

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -31,7 +31,7 @@
         {{ $data := .Data }}
         {{ range $key, $value := .Data.Terms.ByCount }}
         {{ $url := printf "/%s/%s" $data.Plural ($value.Name | urlize) }}
-        <li><a href="{{ $url | absURL }}">{{ $value.Name |title }}</a> {{ $value.Count }}</li>
+        <li><a href="{{ $url | relURL }}">{{ $value.Name |title }}</a> {{ $value.Count }}</li>
         {{ end }}
     </ul>
 </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -35,7 +35,7 @@
           {{ $ncats := sub (len .Params.categories) 1}}
           {{ range $index, $tag := .Params.categories }}
             {{ $url := printf "categories/%s" ( . | urlize) }}
-            <a href="{{ $url | absURL }}">{{ . }}</a>{{if ne $index $ncats }}, {{ end }}
+            <a href="{{ $url | relURL }}">{{ . }}</a>{{if ne $index $ncats }}, {{ end }}
           {{ end }}
         {{ end }}
       </h4>
@@ -50,7 +50,7 @@
           {{ $ntags := sub (len .Params.tags) 1}}
           {{ range $index, $tag := .Params.tags }}
             {{ $url := printf "tags/%s" ( . | urlize) }}
-            <a href="{{ $url | absURL }}">{{ . }}</a>{{if ne $index $ntags }}, {{ end }}
+            <a href="{{ $url | relURL }}">{{ . }}</a>{{if ne $index $ntags }}, {{ end }}
           {{ end }}
         </div>
       </section>

--- a/layouts/partials/article-footer.html
+++ b/layouts/partials/article-footer.html
@@ -14,7 +14,7 @@
 <nav class="pagination" aria-label="Footer">
   <div class="previous">
   {{ if .PrevInSection }}
-      <a href="{{ .PrevInSection.Permalink }}" title="{{ .PrevInSection.Title }}">
+      <a href="{{ .PrevInSection.RelPermalink }}" title="{{ .PrevInSection.Title }}">
         <span class="direction">
           Previous
         </span>
@@ -34,7 +34,7 @@
 
   <div class="next">
   {{ if .NextInSection }}
-      <a href="{{ .NextInSection.Permalink }}" title="{{ .NextInSection.Title }}">
+      <a href="{{ .NextInSection.RelPermalink }}" title="{{ .NextInSection.Title }}">
         <span class="direction">
           Next
         </span>

--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -8,9 +8,9 @@
     {{ end }}
     </script>
 
-    <script src="{{ "javascripts/application.js" | absURL }}"></script>
+    <script src="{{ "javascripts/application.js" | relURL }}"></script>
     {{ range .Site.Params.custom_js }}
-    <script src="{{ . | absURL }}"></script>
+    <script src="{{ . | relURL }}"></script>
     {{ end }}
 
     <script>
@@ -94,7 +94,7 @@
     {{ end }}
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-    <script src="{{ "javascripts/smooth-scroll.min.js" | absURL }}"></script>
+    <script src="{{ "javascripts/smooth-scroll.min.js" | relURL }}"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/languages/pony.min.js"></script>
     <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+  <!--[if lt IE 7 ]><html class="no-js ie6"><![endif]-->
+  <!--[if IE 7 ]><html class="no-js ie7"><![endif]-->
+  <!--[if IE 8 ]><html class="no-js ie8"><![endif]-->
+  <!--[if IE 9 ]><html class="no-js ie9"><![endif]-->
+  <!--[if (gt IE 9)|!(IE)]><!--> <html class="no-js"> <!--<![endif]-->
+
+  <head {{ with .Site.LanguageCode }}lang="{{ . }}"{{ end }}>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=10" />
+    <title>{{ .Title }}{{ if not .IsHome }} - {{ .Site.Title }}{{ end }}</title>
+    {{ .Hugo.Generator }}
+
+    {{ with .Site.Params.description }}
+    <meta name="description" content="{{ . }}">
+    {{ end }}
+    <link rel="canonical" href="{{ .RelPermalink }}">
+    {{ with .Site.Params.author }}
+    <meta name="author" content="{{ . }}">
+    {{ end }}
+
+    <meta property="og:url" content="{{ .RelPermalink }}">
+    {{ with .Site.Title }}<meta property="og:title" content="{{ . }}">{{ end }}
+    {{ with .Site.Params.logo }}<meta property="og:image" content="{{ . | relURL }}">{{ end }}
+    {{ with .Site.Title }}<meta name="apple-mobile-web-app-title" content="{{ . }}">{{ end }}
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+    <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | relURL }}{{ else }}{{ "images/favicon.ico" | relURL }}{{ end }}">
+    <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | relURL }}{{ else }}{{ "images/favicon.ico" | relURL }}{{ end }}">
+
+    <style>
+      @font-face {
+        font-family: 'Icon';
+        src: url('{{ "fonts/icon.eot?52m981" | relURL }}');
+        src: url('{{ "fonts/icon.eot?#iefix52m981" | relURL }}')
+               format('embedded-opentype'),
+             url('{{ "fonts/icon.woff?52m981" | relURL }}')
+               format('woff'),
+             url('{{ "fonts/icon.ttf?52m981" | relURL }}')
+               format('truetype'),
+             url('{{ "fonts/icon.svg?52m981#icon" | relURL }}')
+               format('svg');
+        font-weight: normal;
+        font-style: normal;
+      }
+    </style>
+
+    <link rel="stylesheet" href="{{ "stylesheets/application.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "stylesheets/temporary.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "stylesheets/palettes.css" | relURL }}">
+    <link rel="stylesheet" href="{{ with .Site.Params.highlight_css }}{{ . | relURL }}{{ else }}{{ "stylesheets/highlight/highlight.css" | relURL }}{{ end }}">
+
+    {{/* set default values if no custom ones are defined */}}
+    {{ $text := or .Site.Params.font.text "Roboto" }}
+    {{ $code := or .Site.Params.font.code "Roboto Mono" }}
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family={{ $text }}:400,700|{{ replace  $code " " "+" | safeURL }}">
+    <style>
+      body, input {
+        font-family: '{{ $text }}', Helvetica, Arial, sans-serif;
+      }
+      pre, code {
+        font-family: '{{ $code }}', 'Courier New', 'Courier', monospace;
+      }
+    </style>
+
+    {{ range .Site.Params.custom_css }}
+    <link rel="stylesheet" href="{{ . | relURL }}">
+    {{ end }}
+    <script src="{{ "javascripts/modernizr.js" | relURL }}"></script>
+
+    {{ with .RSSLink }}
+    <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+    <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
+    {{ end }}
+
+  </head>
+  <body class="{{ with .Site.Params.palette.primary }}palette-primary-{{ . }}{{end }} {{ with .Site.Params.palette.accent }}palette-accent-{{ .  }}{{ end }}">

--- a/layouts/partials/list-in-blog.html
+++ b/layouts/partials/list-in-blog.html
@@ -27,7 +27,7 @@
       <h1>{{ .Title | singularize }}</h1>
 
       {{ range .Data.Pages }}
-      <a href="{{ .Permalink }}" title="{{ .Title }}">
+      <a href="{{ .RelPermalink }}" title="{{ .Title }}">
         <h2>{{ .Title }}</h2>
       </a>
       <section class="blog-meta">
@@ -38,7 +38,7 @@
           {{ $ncats := sub (len .Params.categories) 1}}
           {{ range $index, $tag := .Params.categories }}
             {{ $url := printf "categories/%s" ( . | urlize) }}
-            <a href="{{ $url | absURL }}">{{ . }}</a>{{if ne $index $ncats }}, {{ end }}
+            <a href="{{ $url | relURL }}">{{ . }}</a>{{if ne $index $ncats }}, {{ end }}
           {{ end }}
         {{ end }}
       </h4>
@@ -49,7 +49,7 @@
       {{ else }}
       <p>{{ .Description | markdownify }}</p>
       {{ end }}
-      <p class="readmore"><a href="{{ .Permalink }}">Read more...</a></p>
+      <p class="readmore"><a href="{{ .RelPermalink }}">Read more...</a></p>
       <hr>
       {{ end }}
 

--- a/layouts/partials/nav_link.html
+++ b/layouts/partials/nav_link.html
@@ -1,0 +1,13 @@
+{{ $currentMenuEntry := .Scratch.Get "currentMenuEntry" }}
+{{ $isCurrent := eq .RelPermalink ($currentMenuEntry.URL | relURL | printf "%s") }}
+
+
+<a {{ if $isCurrent }}class="current"{{ end }} title="{{ $currentMenuEntry.Name }}" href="{{ $currentMenuEntry.URL | relURL}}">
+  {{ $currentMenuEntry.Pre }}
+  {{ $currentMenuEntry.Name }}
+</a>
+
+{{ if $isCurrent }}
+<ul id="scrollspy">
+</ul>
+{{ end }}


### PR DESCRIPTION
Some hugo templates were using "absURL" for creating some links. This
would result in there being links in the Netlify preview that lead to
the real site. By switching to "relURL", we should be generating
relative URLs that will work correctly in the Netlify previews.

This in turn should allow us to do better inspections of PRs before
pushing them to the live site.