### PR TITLE
Change LWIP submission process from email to GitHub issue

### DIFF
--- a/archetypes/lwip.md
+++ b/archetypes/lwip.md
@@ -9,7 +9,7 @@ title = "Last Week in Pony - Month Day, Year"
 +++
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-032817.md
+++ b/content/blog/last-week-in-pony-032817.md
@@ -9,7 +9,7 @@ description = "Last week's Pony news, reported this week."
 +++
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-040417.md
+++ b/content/blog/last-week-in-pony-040417.md
@@ -9,7 +9,7 @@ description = "Last week's Pony news, reported this week."
 +++
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 ## Items of note

--- a/content/blog/last-week-in-pony-041117.md
+++ b/content/blog/last-week-in-pony-041117.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - April 10, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang).
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 ## Items of note

--- a/content/blog/last-week-in-pony-041717.md
+++ b/content/blog/last-week-in-pony-041717.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - April 17, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-042417.md
+++ b/content/blog/last-week-in-pony-042417.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - April 23, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 ## Pony 0.13.1 released

--- a/content/blog/last-week-in-pony-043017.md
+++ b/content/blog/last-week-in-pony-043017.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - April 30, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 It was a bit of a quiet week in terms of public activity but there's plenty brewing behind the scenes.

--- a/content/blog/last-week-in-pony-050717.md
+++ b/content/blog/last-week-in-pony-050717.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - May 7, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 ## 0.14.0 released

--- a/content/blog/last-week-in-pony-051417.md
+++ b/content/blog/last-week-in-pony-051417.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - May 14, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-052117.md
+++ b/content/blog/last-week-in-pony-052117.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - May 21, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-052817.md
+++ b/content/blog/last-week-in-pony-052817.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - May 28, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-060417.md
+++ b/content/blog/last-week-in-pony-060417.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - June 4, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-061117.md
+++ b/content/blog/last-week-in-pony-061117.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - June 11, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 

--- a/content/blog/last-week-in-pony-061817.md
+++ b/content/blog/last-week-in-pony-061817.md
@@ -10,7 +10,7 @@ title: Last Week in Pony - June 18, 2017
 
 _Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony check out [our website](ponylang.org), our Twitter account [@ponylang](https://twitter.com/ponylang), our [users' mailing list](https://pony.groups.io/g/user) or join us [on IRC](https://webchat.freenode.net/?channels=%23ponylang). 
 
-Got something you think should be featured? Drop us an email at [last.week.in.pony@gmail.com](mailto:last.week.in.pony@gmail.com).
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
 <!--more-->
 
 


### PR DESCRIPTION
I've started using GitHub issues to keep track of content for "Last Week
In Pony". It's an easy way to stay organized. It's far easier to handle
than email.

With this commit, that process is being publicly advertised and other
community members can join in.