### PR TITLE
Highlight FAQ more on the site

### DIFF
--- a/content/community/index.md
+++ b/content/community/index.md
@@ -12,6 +12,7 @@ The most important community resources for those who are new to Pony are:
 
 * #ponylang, our IRC channel on [freenode](https://webchat.freenode.net/?channels=%23ponylang)
 * The [Users Mailing List](https://pony.groups.io/g/user) for discussion of all things Pony that don't involve the development of Pony itself
+* The [frequently asked questions](({{< relref "faq/index.md">}})) section of this website.
 
 If you are looking for help with Pony and can't get a response in #ponylang, we advise that you send an email to the Users Mailing List. 
 

--- a/content/learn/index.md
+++ b/content/learn/index.md
@@ -10,6 +10,8 @@ If you run into trouble while you are learning Pony, don't worry, we've got you 
 * [Mailing list](https://pony.groups.io/g/user).
 * [IRC](https://webchat.freenode.net/?channels=%23ponylang).
 
+Many folks encounter the same issues or have the same questions, be sure to give the [frequently asked questions](({{< relref "faq/index.md">}}) section of this website a read.
+
 Think you've found a bug? It's quite possible. Pony is a relatively young language that is still changing at a rapid pace and bugs do happen. Your best bet. Write to the mailing list with your issue and verify that you are experiencing an issue. Once a more knowledge member of the community confirms you are experiencing a bug, open an issue.
 
 * [Open an issue](https://github.com/ponylang/ponyc/issues)


### PR DESCRIPTION
This commit adds a link to the FAQ to both:

* "Learn" "getting-help" section
* "Community" "getting-started" section