### PR TITLE
Update FAQ with mentioning default_ssl support.

### DIFF
--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -137,13 +137,24 @@ By default, the Pony standard library uses OpenSSL 0.9 for various cryptography 
 ponyc -Dopenssl_1.1.0
 ```
 
-You can also change which openssl library will be used when compiling ponyc by passing `default_openssl=Name`. Where `Name` maybe `openssl_1.1.0` or `openssl_0.9.0`. For example, to set the default ssl library to `openssl_1.1.0` do the following:
+You can compile Pony from source an set OpenSSL 1.1 as the default. Pass `default_openssl=openssl_1.1.0` to the `make` command:
 
 ```bash
 make default_openssl=openssl_1.1.0
 ```
+Regardless of what version of OpenSSL was set as the default when you built Pony, you can always override it by using the appropriate define when compiling your Pony programs. 
 
-The whatever value default_ssl has you can always override it by using the appropriate define, `ponyc -Dopenssl_0.9.0` or `ponyc -Dopenssl_1.1.0`.
+For OpenSSL 0.9:
+
+```bash
+ponyc -Dopenssl_0.9.0
+```
+
+For OpenSSL 1.1:
+
+```bash
+ponyc -Dopenssl_1.1.0
+```
 
 ## Ecosystem {#ecosystem}
 

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -137,11 +137,13 @@ By default, the Pony standard library uses OpenSSL 0.9 for various cryptography 
 ponyc -Dopenssl_1.1.0
 ```
 
-You can also encounter this problem if you try to build the Pony standard library tests via the ponyc Makefile. This can be addressed by adding `OPENSSL=-Dopenssl_1.1.` to the `make` command line:
+You can also change which openssl library will be used when compiling ponyc by passing `default_openssl=Name`. Where `Name` maybe `openssl_1.1.0` or `openssl_0.9.0`. For example, to set the default ssl library to `openssl_1.1.0` do the following:
 
 ```bash
-make OPENSSL=-Dopenssl_1.1.0 test
+make default_openssl=openssl_1.1.0
 ```
+
+The whatever value default_ssl has you can always override it by using the appropriate define, `ponyc -Dopenssl_0.9.0` or `ponyc -Dopenssl_1.1.0`.
 
 ## Ecosystem {#ecosystem}
 

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -137,12 +137,13 @@ By default, the Pony standard library uses OpenSSL 0.9 for various cryptography 
 ponyc -Dopenssl_1.1.0
 ```
 
-You can compile Pony from source an set OpenSSL 1.1 as the default. Pass `default_openssl=openssl_1.1.0` to the `make` command:
+You can compile Pony from source and set OpenSSL 1.1 as the default. Pass `default_openssl=openssl_1.1.0` to the `make` command:
 
 ```bash
 make default_openssl=openssl_1.1.0
 ```
-Regardless of what version of OpenSSL was set as the default when you built Pony, you can always override it by using the appropriate define when compiling your Pony programs. 
+
+By setting OpenSSL 1.1 as the default, you no longer have to pass `-Dopenssl_1.1.0` to `ponyc`. Regardless of what version of OpenSSL was set as the default when you built Pony, you can always override it by using the appropriate define when compiling your Pony programs. 
 
 For OpenSSL 0.9:
 


### PR DESCRIPTION
Here is an update for the FAQ for change [PR 2415](https://github.com/ponylang/ponyc/pull/2415)
