### PR TITLE
Add LWIP automation skill and project CLAUDE.md

### DIFF
--- a/.claude/skills/lwip/SKILL.md
+++ b/.claude/skills/lwip/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: lwip
+description: Create a new "Last Week in Pony" blog post from the open GitHub issue
+disable-model-invocation: true
+---
+
+Create a new "Last Week in Pony" blog post. Follow these steps:
+
+1. **Read editorial guidelines**: Read the "Last Week in Pony" section in
+   this project's CLAUDE.md for format, tone, and domain-specific notes.
+
+2. **Study recent posts**: Read the 2-3 most recent posts in
+   `docs/blog/posts/last-week-in-pony-*.md` for voice calibration.
+
+3. **Find the open issue**: Run
+   `gh issue list --repo ponylang/ponylang.github.io --label last-week-in-pony --state open`
+   to find the current issue, then read it with all comments.
+
+4. **Read release notes**: For any release items in the issue, fetch the
+   release notes (e.g., `gh release view TAG --repo ORG/REPO`) and evaluate
+   whether the release has noteworthy content deserving its own section.
+
+5. **Ask clarifying questions**: Ask the user about any items that are vague
+   or need more context. Do this in a single round if possible — batch your
+   questions.
+
+6. **Write the draft**: Create the post following the format in CLAUDE.md.
+   Use the date from the issue title for the filename and front matter.
+
+7. **Review loop**:
+   a. Spawn a reviewer subagent (using Task tool, subagent_type
+      "general-purpose") with the copy-editing prompt from CLAUDE.md. Pass
+      the full draft content. The reviewer has no conversation history — give
+      it everything it needs in the prompt.
+   b. For each finding: incorporate changes you agree with; if you disagree,
+      present the dispute to the user for a ruling.
+   c. If any changes were made, spawn a new reviewer on the updated content.
+   d. Repeat until a reviewer comes back clean.
+   e. If 3 rounds pass without a clean result, ask the user whether to
+      continue. Check in every 3 rounds thereafter.
+
+8. **Commit and PR**: Create a branch, commit the new post with the message
+   `Last Week in Pony - Month Day, Year`, and open a PR. Report the PR URL
+   to the user.

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -3,3 +3,5 @@ CHANGELOG.md
 CODE_OF_CONDUCT.md
 .release-notes/
 LICENSE.md
+CLAUDE.md
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# Ponylang Website
+
+## Last Week in Pony
+
+### Editorial Guidelines
+
+The tone is informal and Hemingway-esque. Short sentences. Minimal adjectives
+and adverbs except where they serve a conversational tone. The result should
+not sound clipped or like a series of notes — it should read like a person
+talking to you.
+
+Study recent posts in `docs/blog/posts/` for voice calibration before writing.
+
+### Domain-Specific Notes
+
+- "Office Hours" is the title of a meeting and is singular. "Office Hours was
+  attended by..." not "Office Hours were attended by..."
+- The Pony Development Sync is sometimes called just "the sync" in casual
+  context.
+
+### Post Format
+
+**Filename**: `docs/blog/posts/last-week-in-pony-MMDDYY.md`
+
+**Front matter**:
+
+```yaml
+---
+draft: false
+authors:
+  - seantallen
+categories:
+  - "Last Week in Pony"
+title: "Last Week in Pony - Month Day, Year"
+date: YYYY-MM-DDTHH:MM:SS-04:00
+---
+```
+
+**Structure** (in order):
+
+1. Opening hook — 1-2 sentences, conversational, teasing what's in the post
+2. `<!-- more -->` marker
+3. `##` sections for noteworthy items (important releases, announcements, etc.)
+4. `## Items of Note` with `###` subsections (Office Hours, Pony Development
+   Sync, community items)
+5. `## Releases` — bullet list of all releases with links, format:
+   `- [org/repo version](release-url)`
+6. `---` separator
+7. Footer boilerplate (always the same):
+
+```
+_Last Week In Pony_ is a weekly blog post to catch you up on the latest news for the Pony programming language. To learn more about Pony, check out [our website](https://ponylang.io) or our [Zulip community](https://ponylang.zulipchat.com).
+
+Got something you think should be featured? There's a GitHub issue for that! Add a comment to the [open "Last Week in Pony" issue](https://github.com/ponylang/ponylang.github.io/issues?q=is%3Aissue+is%3Aopen+label%3Alast-week-in-pony).
+```
+
+### Releases in Posts
+
+Releases always appear in the `## Releases` bullet list. When a release has
+noteworthy content (bug fixes affecting users, new features, breaking changes),
+it also gets its own `##` section higher in the post with a short write-up.
+Read the release notes to determine if a release warrants its own section. Use
+judgment — routine releases with nothing interesting just go in the list.
+
+### Reviewer Prompt
+
+When spawning a copy-editing reviewer subagent, use a prompt along these lines:
+
+> You are a copy editor. Review the following markdown blog post for grammar
+> and spelling issues. Copy edit for clarity and concision. The tone should be
+> informal and Hemingway-esque — avoid flowery language, minimize adjectives
+> and adverbs except where they serve a conversational tone. The result should
+> not sound clipped or like a series of notes. The conversational aspect of the
+> content should not be lost.
+>
+> Domain note: "Office Hours" is the title of a meeting and is singular.
+>
+> Leave the mkdocs metadata as is. Return the full corrected markdown and then
+> list what changes you made and why.


### PR DESCRIPTION
## Summary

- Adds a `/lwip` Claude Code slash command that automates creating "Last Week in Pony" blog posts from the open GitHub issue, including a copy-editing review loop with subagent reviewers
- Adds project CLAUDE.md with editorial guidelines, post format reference, and domain-specific notes
- Adds CLAUDE.md to `.markdownlintignore`