### PR TITLE
Add post-merge issue rotation to LWIP skill

### DIFF
--- a/.claude/skills/lwip/SKILL.md
+++ b/.claude/skills/lwip/SKILL.md
@@ -42,3 +42,14 @@ Create a new "Last Week in Pony" blog post. Follow these steps:
 8. **Commit and PR**: Create a branch, commit the new post with the message
    `Last Week in Pony - Month Day, Year`, and open a PR. Report the PR URL
    to the user.
+
+9. **Post-merge issue rotation**: After the PR is merged, prompt the user:
+   "PR is merged. Want me to do the post-merge issue rotation?" On
+   confirmation:
+   a. Find the open issue with the `last-week-in-pony` label in
+      `ponylang/ponylang.github.io`.
+   b. Unpin it, remove the `last-week-in-pony` label, and close it.
+   c. Calculate the next Sunday from today's date.
+   d. Create a new empty issue titled
+      `Last Week in Pony - {next Sunday: Month Day, Year}`.
+   e. Add the `last-week-in-pony` label and pin the new issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ Study recent posts in `docs/blog/posts/` for voice calibration before writing.
   attended by..." not "Office Hours were attended by..."
 - The Pony Development Sync is sometimes called just "the sync" in casual
   context.
+- Refer to repositories as `owner/repo` (e.g., `seantallen-org/msgpack`, not
+  `msgpack`) — no one owns a name. This applies everywhere: section headings,
+  inline prose, not just the releases list. Link to the repo on first mention.
 
 ### Post Format
 
@@ -61,6 +64,21 @@ noteworthy content (bug fixes affecting users, new features, breaking changes),
 it also gets its own `##` section higher in the post with a short write-up.
 Read the release notes to determine if a release warrants its own section. Use
 judgment — routine releases with nothing interesting just go in the list.
+
+### Post-Merge Process
+
+After the LWIP PR is merged:
+
+1. Find the open issue with the `last-week-in-pony` label in
+   `ponylang/ponylang.github.io`.
+2. Unpin it, remove the `last-week-in-pony` label, and close it.
+3. Create a new empty issue titled
+   `Last Week in Pony - {next Sunday: Month Day, Year}`.
+4. Add the `last-week-in-pony` label and pin the new issue.
+
+"Next Sunday" means the next Sunday from today. The post usually goes out on
+Sunday, but occasionally slips to Monday — the issue title always uses the
+Sunday date regardless.
 
 ### Reviewer Prompt
 


### PR DESCRIPTION
## Summary

- Adds a post-merge issue rotation step to the LWIP skill (step 9): after the PR is merged, prompt the user then close/unpin the old issue and create/pin/label the next week's issue.
- Documents the post-merge process in CLAUDE.md as a standalone reference.
- Adds `owner/repo` naming convention to domain-specific notes.