### PR TITLE
Replace homepage with content-rich landing page

### DIFF
--- a/.spelling-wordlist.txt
+++ b/.spelling-wordlist.txt
@@ -359,6 +359,7 @@ multithreading
 Mumm
 Mumm's
 musl
+mutexes
 mwahl
 namespace
 natively

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,137 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 # Pony
 
-Welcome! This is the website for the Pony programming language. Pony is an open-source, object-oriented, actor-model, capabilities-secure, high-performance programming language.
+An open-source, object-oriented, actor-model, capabilities-secure, high-performance programming language.
 
-## Quick links
+[Get Started](learn/getting-started.md){ .md-button .md-button--primary }
+[Try It in Your Browser](https://playground.ponylang.io/){ .md-button target=_blank }
+[Install](https://github.com/ponylang/ponyc/blob/main/INSTALL.md){ .md-button target=_blank }
 
-- [What is Pony?](/discover/index.md)
-- [Frequently asked questions](faq/about-pony.md)
-- [Try it in your browser](https://playground.ponylang.io/)
-- [Example Pony applications](https://github.com/ponylang/ponyc/tree/main/examples)
-- [Installation](https://github.com/ponylang/ponyc/blob/main/INSTALL.md)
-- [Get started learning Pony](learn/getting-started.md)
+## What Pony Guarantees
+
+### Type safe
+
+*Really* type safe. There's a mathematical [proof](/media/papers/fast-cheap-with-proof.pdf) and everything.
+
+### Memory safe
+
+No dangling pointers. No buffer overruns. No null.
+
+### Data-race free
+
+Pony doesn't have locks or atomic operations. The type system ensures at compile time that your concurrent program can never have data races.
+
+### Deadlock-free
+
+Pony has no locks at all. They can't deadlock because they don't exist.
+
+### Exception-safe
+
+No runtime exceptions. All exceptions have defined semantics, and they are *always* caught.
+
+### Native code
+
+Pony is an ahead-of-time (AOT) compiled language. No interpreter. No virtual machine.
+
+### Compatible with C
+
+Pony programs can natively call C libraries using the foreign function interface.
+
+## See It in Action
+
+Three actors coordinate a party. `Main` tells `Party` to add friends. `Party` creates a `Friend` actor for each one and sends it an invite. Each `Friend` decides whether to attend and sends back an RSVP. When all responses are in, `Party` prints the guest list.
+
+No locks. No mutexes. No synchronization primitives. The type system handles it.
+
+```pony
+actor Party
+  let _env: Env
+  var _guests: Array[String val] = _guests.create()
+  var _expected: USize = 0
+  var _responded: USize = 0
+
+  new create(env: Env) =>
+    _env = env
+
+  be add_friend(name: String val) =>
+    _expected = _expected + 1
+    Friend(name).invite(this)
+
+  be rsvp(name: String val, attending: Bool) =>
+    _responded = _responded + 1
+    if attending then
+      _guests.push(name)
+    end
+    if _responded == _expected then
+      _env.out.print("Party guest list:")
+      for guest in _guests.values() do
+        _env.out.print("  " + guest)
+      end
+    end
+
+actor Friend
+  let _name: String val
+
+  new create(name: String val) =>
+    _name = name
+
+  be invite(party: Party) =>
+    // friends with short names are too busy
+    let attending = _name.size() > 3
+    party.rsvp(_name, attending)
+
+actor Main
+  new create(env: Env) =>
+    let party = Party(env)
+
+    party.add_friend("Alice")
+    party.add_friend("Bob")
+    party.add_friend("Carol")
+```
+
+[Try this example in the Playground](https://playground.ponylang.io/?gist=965abaa0cb468c36d241582768265e29){ .md-button target=_blank }
+[More examples](https://github.com/ponylang/ponyc/tree/main/examples){ .md-button target=_blank }
+
+## Pony's Design Philosophy
+
+Pony's philosophy is "get-stuff-done." Every design decision follows a clear priority order:
+
+**Correctness** comes first. Incorrectness is simply not allowed. It's pointless to get stuff done if you can't guarantee the result is correct.
+
+**Performance** is second. Runtime speed is more important than everything except correctness.
+
+**Simplicity** is third. It's ok to make things a bit harder on the programmer to improve performance, but it's more important to make things easier on the programmer than on the language runtime.
+
+This philosophy shapes concrete commitments: a program that compiles should never crash. All semantics are fully defined — nothing is left "implementation dependent." There is no ambiguity — the programmer should never have to guess what the compiler will do. There is no "trust me, I know what I'm doing" escape hatch.
+
+[The Pony Philosophy](discover/pony-philosophy.md) | [Guiding Principles](discover/guiding-principles.md)
+
+## Why Pony?
+
+Pony makes it easy to write fast, safe, highly concurrent programs. The type system introduces *reference capabilities* — labels you put on data that describe how it can be shared. The compiler verifies you're handling data correctly based on those labels. Share only immutable data. Exchange only isolated data. The compiler enforces both. No locks needed.
+
+If you ask us, that's pretty damn cool.
+
+[Read the full argument](discover/why-pony.md)
+
+## Why Not Pony?
+
+We believe in being honest. Pony hasn't reached version 1.0. Breaking changes still happen. The pool of ready-to-use libraries is small. There's no IDE. If your project needs a large ecosystem and stable APIs right now, Pony isn't the right choice today.
+
+But if you see the potential, we'd love for you to give it a try.
+
+[Read more](discover/why-not-pony.md)
+
+## Start Learning
+
+- [Install Pony](https://github.com/ponylang/ponyc/blob/main/INSTALL.md)
 - [Tutorial](https://tutorial.ponylang.io/)
+- [Reference Capabilities](learn/reference-capabilities.md)
+- [Example Applications](https://github.com/ponylang/ponyc/tree/main/examples)
 - [Standard Library Documentation](https://stdlib.ponylang.io/)
-- [Getting help](learn/getting-help.md)
-- [Existing user reference](use/index.md)
-- [Community resources](community/index.md)
-- [Community Norms](community/norms.md)
-- [How to contribute](contribute/index.md)
-- [Releases](https://github.com/ponylang/ponyc/releases)
+- [Getting Help](learn/getting-help.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,18 @@
 site_name: Pony
 
-copyright: Copyright &copy; 2025 The Pony Developers
+copyright: >-
+  <strong>Resources</strong>:
+  <a href="/blog/">Blog</a> |
+  <a href="/faq/">FAQ</a> |
+  <a href="https://github.com/ponylang/ponyc/releases">Releases</a> |
+  <a href="/community/planet-pony/">Planet Pony</a>
+  <br>
+  <strong>Project</strong>:
+  <a href="/sponsors/">Sponsors</a> |
+  <a href="/community/norms/">Community Norms</a> |
+  <a href="/contribute/">Contributing</a>
+  <br>
+  Copyright &copy; 2025 The Pony Developers
 edit_uri: edit/main/docs/
 repo_url: https://github.com/ponylang/ponylang-website/
 site_url: https://www.ponylang.io/
@@ -13,6 +25,9 @@ extra:
       link: https://github.com/ponylang
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/ponylang
+    - icon: fontawesome/solid/comments
+      link: https://ponylang.zulipchat.com/
+      name: Zulip
 
 markdown_extensions:
   - admonition
@@ -114,13 +129,6 @@ theme:
 
 nav:
   - Home: "index.md"
-  - Discover:
-      - What is Pony?: "discover/index.md"
-      - What makes Pony different?: "discover/what-makes-pony-different.md"
-      - Why Pony?: "discover/why-pony.md"
-      - Why not Pony?: "discover/why-not-pony.md"
-      - The Pony Philosophy: "discover/pony-philosophy.md"
-      - Guiding Principles: "discover/guiding-principles.md"
   - Learn:
       - Getting Help: "learn/getting-help.md"
       - Installing Pony: "learn/installing-pony.md"
@@ -183,4 +191,3 @@ nav:
       - Ecosystem: "faq/ecosystem.md"
       - Linking: "faq/linking.md"
       - Runtime: "faq/runtime.md"
-  - Sponsors: "sponsors/index.md"

--- a/website-reorg-notes.md
+++ b/website-reorg-notes.md
@@ -1,0 +1,286 @@
+# Website Reorganization Notes
+
+## The Three-Persona Model
+
+The site serves three audiences at different stages of the same journey:
+
+1. **Discover** — "Should I invest my time learning Pony?"
+2. **Learn** — "I've decided to learn. Guide me."
+3. **Use** — "I'm a Pony programmer. What do I need day-to-day?"
+
+## Current Structure
+
+Seven top-level tabs: Discover, Learn, Use, Contribute, Community, Blog, FAQ,
+plus Sponsors and a Home page that is mostly a flat list of quick links.
+
+### Current Discover section
+
+- What is Pony? (short intro, links to playground and history)
+- What makes Pony different? (type safe, memory safe, data-race free, etc.)
+- Why Pony? (deeper refcaps argument)
+- Why not Pony? (honest tradeoffs)
+- The Pony Philosophy (correctness > performance > simplicity hierarchy)
+- Guiding Principles (language design commitments)
+
+### Current Learn section
+
+Mostly outbound links — Tutorial, Patterns, stdlib docs, a cheat sheet PDF. The
+only substantial content is the reference capabilities learning path. "Getting
+Help" and "Installing Pony" are logistical. "Getting Started" is a list of
+links. Thin for a section meant to guide people through learning.
+
+### Current Use section
+
+Debugging, performance, testing, dependency management, packages,
+infrastructure. Serves its intent fairly well as practitioner material.
+
+## Research: How Other Language Sites Handle This
+
+Reviewed Rust, Go, Elixir, Zig, Gleam, Erlang, Nim, and Crystal.
+
+**Key finding**: Every site puts the evaluation/pitch content directly on the
+homepage. None have a separate "Discover" tab. The homepage does that job.
+
+Common homepage pattern:
+
+1. Hero (tagline + CTA)
+2. Key differentiators (3-4 pillars or features)
+3. Code sample(s)
+4. Use cases or social proof
+5. Community/getting started CTAs
+
+Two things Pony's site is missing that others do well:
+
+- **Code on the homepage.** Nearly every other language site shows actual code.
+- **"What is this good for?"** Go has case studies, Rust has domain cards,
+  Elixir has tagged case studies. Pony says what it *is* but not what you'd
+  *build with it*.
+
+## Decisions Made
+
+- **"What is Pony?" and "What makes Pony different?" get absorbed into the
+  homepage.** They're short and punchy enough to be homepage sections, not
+  separate pages.
+- **Philosophy and Guiding Principles are evaluation content, not internal
+  project docs.** Knowing that correctness is valued above performance, that the
+  project promises "no crashes" and "fully defined semantics" — these are
+  commitments that affect what a user can expect. They belong in the Discover
+  story, not in Learn or Contribute.
+- **Not all Discover content belongs on the homepage.** The full Why Pony,
+  Why Not Pony, Philosophy, and Guiding Principles pages are too much for a
+  single page. The homepage should have condensed/teaser versions with links to
+  the full pages.
+- **The Discover tab probably goes away.** Its deeper pages still exist but are
+  linked from the homepage rather than living behind their own tab. Not fully
+  decided yet.
+- **The current homepage quick links serve a real purpose** — people have
+  requested easy access to those destinations. The new homepage needs to
+  preserve that wayfinding, just organized by intent rather than listed flat.
+
+## Proposed Homepage Shape
+
+### Hero
+
+One-liner: what Pony is. Two buttons: `Get Started` | `Try It in Your Browser`
+
+### What Makes Pony Different
+
+(Absorbed from current page.) The punchy list — type safe, memory safe,
+data-race free, deadlock-free, exception-safe, native code, C-compatible. Short
+descriptions for each.
+
+### [Code Sample]
+
+A small, compelling Pony example showing actors and message passing.
+
+### How Pony Thinks
+
+(Drawn from Philosophy + Guiding Principles, reframed as promises to the user.)
+The correctness > performance > simplicity hierarchy. Key commitments: "no
+crashes," "fully defined semantics," "no ambiguity." Links to full Philosophy
+and Guiding Principles pages.
+
+### Why Pony / Why Not Pony
+
+(Teaser + links.) A short paragraph or two — the essence of the refcaps
+argument and the honest tradeoffs. Links to the full versions.
+
+### Get Going
+
+(Wayfinding, replaces current quick links.) Three clear paths, one per persona:
+
+**Learn Pony**: Tutorial, Getting Started, Reference Capabilities guide,
+Example applications
+
+**Use Pony**: Installation, Standard Library docs, Packages, Debugging /
+Performance / Testing guides
+
+**Join the Community**: Zulip, Getting Help, Office Hours, How to Contribute
+
+### Footer
+
+FAQ, Releases, Community Norms, Blog — findable but not prominently placed.
+
+## Homepage Code Sample
+
+### Research
+
+Searched all Pony code in `ponylang/` and `seantallen-org/` repos. Best
+existing candidates:
+
+- **Counter** (`ponyc/examples/counter/`) — Two actors, 32 lines. Main creates
+  a Counter, sends `increment()` messages, asks for result back via
+  `get_and_reset(this)`. Counter replies by calling `main.display()`. Clear
+  message passing, right size.
+- **Ring** (`ponyc/examples/ring/`) — Actors linked in a circle passing
+  messages. Compelling concurrency narrative but 129 lines as-is. Would need
+  heavy trimming (remove CLI parsing) to get to ~20 lines.
+- **Mailbox** (`ponyc/examples/mailbox/`) — Multiple senders, one receiver.
+  Fan-in pattern. Less visually interesting.
+
+Everything else (fan-in, http_server, postgres, lori, reactive streams, msgpack)
+is too long, too domain-specific, or doesn't foreground actors.
+
+### The Problem
+
+None of the existing examples fully demonstrate "data-race freedom" in a way
+that's immediately visible to a newcomer. Counter shows actors and message
+passing, but a newcomer might think "I could do this with a function call."
+The safety story is about what's *absent* — no locks, no mutexes, no
+synchronization — and that's hard to show in code alone.
+
+### Option A: Workers and Collector
+
+Custom-written. Three Worker actors each receive a reversed string, reverse it,
+and send the result to a Collector. The Collector streams results as they arrive
+and prints a joined summary when all are in. Surrounding homepage text (not
+inline comments) explains what's happening.
+
+Shows: `val` (immutable strings passed between actors), `consume` (ownership
+transfer), `iso` (return type of `reverse()` and `join()`), actors with private
+mutable state (`_results`), no locks/synchronization.
+
+```pony
+actor Collector
+  let _env: Env
+  var _results: Array[String val] = _results.create()
+  let _expected: USize
+
+  new create(env: Env, expected: USize) =>
+    _env = env
+    _expected = expected
+
+  be collect(result: String val) =>
+    _results.push(result)
+    _env.out.print(result)
+    if _results.size() == _expected then
+      let summary = " | ".join(_results.values())
+      _env.out.print("---")
+      _env.out.print("All done: " + consume summary)
+    end
+
+actor Worker
+  let _collector: Collector
+
+  new create(collector: Collector) =>
+    _collector = collector
+
+  be run(name: String val, task: String val) =>
+    let reversed = task.reverse()
+    let result: String val = name + " finished: " + consume reversed
+    _collector.collect(result)
+
+actor Main
+  new create(env: Env) =>
+    let collector = Collector(env, 3)
+
+    Worker(collector).run("Alice", "atad ezylana")
+    Worker(collector).run("Bob", "troper dnes")
+    Worker(collector).run("Carol", "sgol kcehc")
+```
+
+Verified to compile. Runs instantly (playground-compatible). Tasks read as
+gibberish in, english out ("Alice finished: analyze data").
+
+### Option B: Party Invitations
+
+Custom-written. Main creates a Party actor and sends it three `add_friend`
+messages. For each friend, Party creates a Friend actor inline and invites it.
+Each Friend decides whether to attend (name length > 3) and sends an RSVP back
+to the Party. When all responses are in, Party prints the guest list.
+
+Shows: `val` (immutable strings passed between actors), actors with private
+mutable state (`_guests`, `_expected`, `_responded`), lightweight inline actor
+creation (`Friend(name).invite(this)`), three-hop message flow
+(Main → Party → Friend → Party), no locks/synchronization. Actor scheduling
+means output order isn't guaranteed — demonstrates real concurrency.
+
+Source in `homepage-example/main.pony`.
+
+```pony
+actor Party
+  let _env: Env
+  var _guests: Array[String val] = _guests.create()
+  var _expected: USize = 0
+  var _responded: USize = 0
+
+  new create(env: Env) =>
+    _env = env
+
+  be add_friend(name: String val) =>
+    _expected = _expected + 1
+    Friend(name).invite(this)
+
+  be rsvp(name: String val, attending: Bool) =>
+    _responded = _responded + 1
+    if attending then
+      _guests.push(name)
+    end
+    if _responded == _expected then
+      _env.out.print("Party guest list:")
+      for guest in _guests.values() do
+        _env.out.print("  " + guest)
+      end
+    end
+
+actor Friend
+  let _name: String val
+
+  new create(name: String val) =>
+    _name = name
+
+  be invite(party: Party) =>
+    // friends with short names are too busy
+    let attending = _name.size() > 3
+    party.rsvp(_name, attending)
+
+actor Main
+  new create(env: Env) =>
+    let party = Party(env)
+
+    party.add_friend("Alice")
+    party.add_friend("Bob")
+    party.add_friend("Carol")
+```
+
+Verified to compile and run. Output (order may vary due to actor scheduling):
+
+```text
+Party guest list:
+  Carol
+  Alice
+```
+
+Advantages over Option A: more relatable metaphor (everyone understands party
+invitations), richer message flow (three hops vs two), Friend actors have
+autonomy (they decide), inline actor creation shows how lightweight actors are.
+Disadvantages: no visible `consume`/`iso` usage.
+
+## Still To Decide
+
+- Whether a Discover tab exists or if the deeper pages are just linked from
+  the homepage.
+- What the Learn section should look like if it gets meatier.
+- Whether Contribute should split "how to help" from internal maintainer docs.
+- What happens to FAQ as a top-level section vs. content folded into other
+  sections.


### PR DESCRIPTION
Absorb Discover content into the homepage following the pattern used by Rust, Go, Elixir, and other language sites.

New homepage structure:
- Hero with CTA buttons (Get Started, Try It in Your Browser, Install)
- What Pony Guarantees — the feature list from the current Discover page
- Code sample — party invitations showing actors, message passing, and `val`
- Pony's Design Philosophy — condensed Philosophy and Guiding Principles
- Why Pony / Why Not Pony teasers with links to full pages
- Focused Start Learning section

Other changes:
- Remove Discover and Sponsors tabs from nav
- Structured footer with Resources (Blog, FAQ, Releases, Planet Pony) and Project (Sponsors, Community Norms, Contributing) sections
- Add Zulip social icon

Working notes captured in `website-reorg-notes.md`. Open questions posted in discussion #1152.