### PR TITLE
Advertise the ponyc Git repository in the site header

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ copyright: >-
   <a href="/contribute/">Contributing</a>
   <br>
   Copyright &copy; 2025 The Pony Developers
-edit_uri: edit/main/docs/
-repo_url: https://github.com/ponylang/ponylang-website/
+edit_uri: https://github.com/ponylang/ponylang-website/edit/main/docs/
+repo_url: https://github.com/ponylang/ponyc
 site_url: https://www.ponylang.io/
 use_directory_urls: !ENV [USE_DIRECTORY_URLS, true]
 
@@ -71,7 +71,7 @@ plugins:
         - https://stackoverflow.com/*
         - https://www.gnuradio.org/*
         - https://medium.com/*
-        
+
   - rss:
       match_path: blog/posts/.*
       date_from_meta:


### PR DESCRIPTION
## Context

The website's repository link in the menu bar currently points to this documentation repository (ponylang-website).

<img width="1176" height="45" alt="image" src="https://github.com/user-attachments/assets/efd197e1-9399-4074-9268-031b8db9c7c4" />


Curious readers are likely more interested in the [ponyc](https://github.com/ponylang/ponyc) repository.

## Changes

- Changed `repo_url` to point to ponyc
- Updated `edit_uri` to use an absolute URL to ensure edit links to continue linking to the documentation source in this `ponylang-website` repository

## Consequences

The repository icon in the site's menu bar now links to the ponyc repository, while "Edit this page" links continue to point to the documentation repository where the website content source is located.

<img width="174" height="39" alt="image" src="https://github.com/user-attachments/assets/fc94069a-ee0d-446b-baf6-fb8d7add438a" />

The version number of the latest Pony release is now included. 


