### PR TITLE
Remove the GitHub link from the site header

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,7 @@
 site_name: Pony
 
 copyright: Copyright &copy; 2025 The Pony Developers
-edit_uri: edit/main/docs/
-repo_url: https://github.com/ponylang/ponylang-website/
+edit_uri: https://github.com/ponylang/ponylang-website/edit/main/docs/
 site_url: https://www.ponylang.io/
 use_directory_urls: !ENV [USE_DIRECTORY_URLS, true]
 
@@ -56,7 +55,7 @@ plugins:
         - https://stackoverflow.com/*
         - https://www.gnuradio.org/*
         - https://medium.com/*
-        
+
   - rss:
       match_path: blog/posts/.*
       date_from_meta:


### PR DESCRIPTION
## Context

The website header includes a link to the documentation repository. This link may be distracting, as the focus should be on the Pony language rather than on Git repository infrastructure. Additionally, the Pony ecosystem comprises a vast collection of repositories, so advertising a single repository here would not be accurate and could confuse readers.

<img width="1176" height="45" alt="image" src="https://github.com/user-attachments/assets/3069b7db-cb74-4878-8c26-44168d3bd880" />


## Changes

- Removed `repo_url` from the MkDocs configuration
- Updated `edit_uri` to use an absolute URL so "Edit this page" links continue working

## Consequences

The GitHub repository icon and link is removed from the site header, simplifying and focusing the navigation. The "Edit this page" functionality on individual pages continues to work as before.
