### PR TITLE
Fix raspbios typo in RPi development docs

### DIFF
--- a/.cspell/pony-terms.txt
+++ b/.cspell/pony-terms.txt
@@ -232,7 +232,6 @@ Pygments
 QUIC
 quickstart
 Radisson
-raspbios
 raspios
 RDMA
 redvers

--- a/docs/contribute/developer-resources/arm-development-with-rpi-4.md
+++ b/docs/contribute/developer-resources/arm-development-with-rpi-4.md
@@ -30,7 +30,7 @@ Raspbian downloads are available from the [Raspberry Pi downloads site](https://
 
 For 32-bit installs you want to download a .zip image of [raspios_lite_armhf](https://downloads.raspberrypi.org/raspios_armhf/).
 
-For 64-bit installs you want to download a .zip image of[raspbios_lite_arm64](https://downloads.raspberrypi.org/raspios_arm64/).
+For 64-bit installs you want to download a .zip image of [raspios_lite_arm64](https://downloads.raspberrypi.org/raspios_arm64/).
 
 ## Pre-boot Raspbian setup
 


### PR DESCRIPTION
The 64-bit image link text had "raspbios" instead of "raspios" and was missing a space before the markdown link.