### PR TITLE
Add pony-lint rule reference with examples

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -32,12 +32,14 @@ pony-lint --version
 | `style/comment-spacing` | on | `//` not followed by exactly one space |
 | `style/file-naming` | on | File name should match principal type |
 | `style/hard-tabs` | on | Tab characters anywhere in source |
-| `style/line-length` | on | Lines exceeding 80 columns |
+| `style/line-length` | on | Lines exceeding 80 codepoints |
 | `style/member-naming` | on | Member names should be snake_case |
 | `style/package-naming` | off | Package directory name should be snake_case |
 | `style/public-docstring` | on | Public types and methods should have a docstring |
 | `style/trailing-whitespace` | on | Trailing spaces or tabs |
 | `style/type-naming` | on | Type names should be CamelCase |
+
+See the [Rule Reference](linting/rule-reference.md) for detailed explanations and code examples for each rule.
 
 ## Configuration
 

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -1,0 +1,257 @@
+# Rule Reference
+
+Each rule is listed with its default status, a description of what it checks, and examples of incorrect and correct code.
+
+## `style/acronym-casing`
+
+**Default:** on
+
+Known acronyms in type names must be fully uppercased. The recognized acronyms are: API, AST, CSS, DNS, FFI, FIFO, HTML, HTTP, IMAP, JSON, MIME, SMTP, SSH, SSL, TCP, TLS, UDP, URI, URL, UUID, XML.
+
+**Incorrect:**
+
+```pony
+class JsonParser
+
+primitive HttpMethod
+```
+
+**Correct:**
+
+```pony
+class JSONParser
+
+primitive HTTPMethod
+```
+
+## `style/comment-spacing`
+
+**Default:** on
+
+Line comments (`//`) must be followed by exactly one space. An empty comment (`//` with nothing after it) is also acceptable. This rule does not apply inside string literals, including triple-quoted strings.
+
+**Incorrect:**
+
+```pony
+//This comment has no space
+//  This comment has two spaces
+```
+
+**Correct:**
+
+```pony
+// This comment has one space
+//
+// Empty comment above is fine
+let url = "http://example.com" // inside strings is ignored
+```
+
+## `style/file-naming`
+
+**Default:** on
+
+The file name must match the principal type defined in the file, converted to snake_case. The principal type is determined by a heuristic: if the file contains a single entity, that entity is principal. If a trait or interface is present alongside other types, the trait or interface is principal. Files with multiple unrelated types (no clear principal) are not checked. Private types preserve their leading underscore in the filename.
+
+Files named `_test.pony` that contain a `Main` actor are exempt (standard test runner convention).
+
+**Incorrect:**
+
+```pony
+// File: parser.pony
+class FooParser
+  // Error: expected file name foo_parser.pony
+```
+
+**Correct:**
+
+```pony
+// File: foo_parser.pony
+class FooParser
+
+// File: _private_helper.pony
+class _PrivateHelper
+
+// File: runnable.pony
+trait Runnable
+class Runner // trait is principal, so runnable.pony is correct
+```
+
+## `style/hard-tabs`
+
+**Default:** on
+
+Tab characters are not allowed anywhere in source files. Pony uses spaces for indentation.
+
+A violation is a literal tab character in the source. Since tabs are invisible in rendered text, a tab-indented line looks like a space-indented line but triggers this rule. Editors should be configured to insert spaces instead of tabs.
+
+**Correct:**
+
+```pony
+actor Main
+  new create(env: Env) =>
+    env.out.print("spaces, not tabs")
+```
+
+## `style/line-length`
+
+**Default:** on
+
+Lines must not exceed 80 codepoints. Multi-byte UTF-8 characters count as one codepoint each. A line of exactly 80 codepoints is acceptable; 81 or more triggers a violation.
+
+**Incorrect:**
+
+```pony
+// The following line is too long
+let description = "This string is far too long to fit within the eighty codepoint limit for lines"
+```
+
+**Correct:**
+
+```pony
+let description =
+  "This string has been split" +
+  " across multiple lines"
+```
+
+## `style/member-naming`
+
+**Default:** on
+
+Fields, methods, parameters, and local variables must use snake_case. Names may start with a leading underscore for private visibility. The discard pattern `_` by itself is not checked. Trailing primes (e.g., `value'`) are permitted.
+
+**Incorrect:**
+
+```pony
+class Foo
+  let myField: U32 = 0
+  var someValue: String = ""
+
+  fun doSomething(): None =>
+    let myVar: U32 = 1
+    None
+```
+
+**Correct:**
+
+```pony
+class Foo
+  let my_field: U32 = 0
+  var _some_value: String = ""
+
+  fun do_something(): None =>
+    let my_var: U32 = 1
+    None
+```
+
+## `style/package-naming`
+
+**Default:** off
+
+The package directory name must be snake_case, containing only lowercase letters, digits, and underscores. This rule is off by default because application packages often use hyphens to match CLI naming conventions.
+
+**Incorrect (if enabled):**
+
+```text
+MyPackage/
+  main.pony
+
+my-package/
+  main.pony
+```
+
+**Correct:**
+
+```text
+my_package/
+  main.pony
+```
+
+## `style/public-docstring`
+
+**Default:** on
+
+Public types and public methods must have a docstring. A type or method is public if its name does not start with `_`.
+
+Several exemptions apply. No docstring is required for:
+
+- Types or methods annotated with `\nodoc\`
+- Methods inside private types or `\nodoc\`-annotated types
+- `Main` actors
+- Well-known method names: `create`, `string`, `eq`, `ne`, `hash`, `hash64`, `compare`, `lt`, `le`, `ge`, `gt`, `dispose`, `has_next`, `next`, `values`, `size`
+- Type aliases (Pony does not support docstrings on type aliases)
+- Methods inside anonymous `object` literals
+- Concrete methods with 3 or fewer top-level expressions in the body (abstract methods are not exempt)
+
+**Incorrect:**
+
+```pony
+class Foo
+  fun my_method(a: U32, b: U32, c: U32, d: U32): U32 =>
+    let x = a + b
+    let y = c + d
+    let z = x * y
+    z + 1
+```
+
+**Correct:**
+
+```pony
+class Foo
+  """A class that does arithmetic."""
+
+  fun my_method(a: U32, b: U32, c: U32, d: U32): U32 =>
+    """Combine four values through addition and multiplication."""
+    let x = a + b
+    let y = c + d
+    let z = x * y
+    z + 1
+
+  fun apply(): U32 =>
+    // Exempt: 3 or fewer expressions
+    let x: U32 = 1
+    let y: U32 = 2
+    x + y
+```
+
+## `style/trailing-whitespace`
+
+**Default:** on
+
+Lines must not have trailing spaces or tabs. Completely empty lines (zero length) are not flagged.
+
+Because trailing whitespace is invisible in rendered text, violations are not visible in code examples. A violation is one or more space or tab characters between the last visible character on a line and the line ending.
+
+**Correct:**
+
+```pony
+class Foo
+  fun apply(): None =>
+    let x = 1
+    None
+```
+
+## `style/type-naming`
+
+**Default:** on
+
+Type names must use CamelCase. Names may start with a leading underscore for private visibility. After the optional leading underscore, the name must begin with an uppercase letter and contain only letters and digits. Underscores within the name are not allowed. Trailing primes are permitted.
+
+**Incorrect:**
+
+```pony
+class foo_parser
+
+primitive my_helper
+
+actor some_actor
+```
+
+**Correct:**
+
+```pony
+class FooParser
+
+primitive _MyHelper
+
+actor SomeActor
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,7 +145,9 @@ nav:
       - Documentation Generation: "use/documentation.md"
       - Dependency Management: "use/dependency-management.md"
       - Infrastructure: "use/infrastructure.md"
-      - Linting: "use/linting.md"
+      - Linting:
+          - Overview: "use/linting.md"
+          - Rule Reference: "use/linting/rule-reference.md"
       - Packages: "use/packages.md"
       - Performance:
           - Overview: "use/performance.md"


### PR DESCRIPTION
Adds a Rule Reference sub-page to the Linting section documenting all 10 released pony-lint rules with descriptions, incorrect examples, and correct examples. The existing linting overview page gets a link to the reference and a minor fix ("columns" → "codepoints" for the line-length rule description).

The Linting nav entry is converted from a flat page to a section with Overview + Rule Reference, matching the pattern used by Debugging, Testing, and Performance.

Closes #1169