### PR TITLE
Add structural formatting lint rules to reference

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -29,12 +29,18 @@ pony-lint --version
 | Rule ID | Default | Description |
 |---------|---------|-------------|
 | `style/acronym-casing` | on | Acronyms in type names should be fully uppercased |
+| `style/blank-lines` | on | Blank line conventions within and between entities |
 | `style/comment-spacing` | on | `//` not followed by exactly one space |
+| `style/dot-spacing` | on | No spaces around `.`; `.>` spaced as infix operator |
 | `style/file-naming` | on | File name should match principal type |
 | `style/hard-tabs` | on | Tab characters anywhere in source |
 | `style/line-length` | on | Lines exceeding 80 codepoints |
+| `style/match-case-indent` | on | Match case `\|` must align with `match` keyword |
+| `style/match-no-single-line` | on | Match expressions must span multiple lines |
 | `style/member-naming` | on | Member names should be snake_case |
 | `style/package-naming` | off | Package directory name should be snake_case |
+| `style/partial-call-spacing` | on | `?` at call site must immediately follow `)` |
+| `style/partial-spacing` | on | `?` in method declaration needs surrounding spaces |
 | `style/public-docstring` | on | Public types and methods should have a docstring |
 | `style/trailing-whitespace` | on | Trailing spaces or tabs |
 | `style/type-naming` | on | Type names should be CamelCase |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -24,6 +24,44 @@ class JSONParser
 primitive HTTPMethod
 ```
 
+## `style/blank-lines`
+
+**Default:** on
+
+Blank line conventions within and between entities.
+
+Within entities:
+
+- No blank line between the entity declaration and the first body content (docstring or first member).
+- No blank lines between consecutive fields.
+- Exactly one blank line before each method. Exception: when both the preceding method and the current method are one-liners, zero blank lines are also allowed.
+
+Between entities:
+
+- Exactly one blank line between consecutive entities. Exception: when both entities are one-liners, zero blank lines are also allowed.
+
+**Incorrect:**
+
+```pony
+class Foo
+
+  let x: U32 = 0
+
+  let y: U32 = 1
+
+  fun apply(): U32 => x + y
+```
+
+**Correct:**
+
+```pony
+class Foo
+  let x: U32 = 0
+  let y: U32 = 1
+
+  fun apply(): U32 => x + y
+```
+
 ## `style/comment-spacing`
 
 **Default:** on
@@ -44,6 +82,32 @@ Line comments (`//`) must be followed by exactly one space. An empty comment (`/
 //
 // Empty comment above is fine
 let url = "http://example.com" // inside strings is ignored
+```
+
+## `style/dot-spacing`
+
+**Default:** on
+
+`.` must have no spaces around it. `.>` must be spaced as an infix operator with spaces on both sides. Both operators skip the "before" check on continuation lines where the operator is the first non-whitespace character.
+
+**Incorrect:**
+
+```pony
+let x = foo .bar
+let y = foo. bar
+let z = foo.>bar
+```
+
+**Correct:**
+
+```pony
+let x = foo.bar
+let y = foo .> bar
+
+// Continuation lines are fine
+let z = foo
+  .bar
+  .> baz
 ```
 
 ## `style/file-naming`
@@ -113,6 +177,53 @@ let description =
   " across multiple lines"
 ```
 
+## `style/match-case-indent`
+
+**Default:** on
+
+The `|` introducing each match case must align with the `match` keyword's column. This makes the match structure visually clear regardless of nesting depth. Inline continuation pipes (e.g., `| "a" | "b"`) are not checked since only the leading `|` on each line needs alignment.
+
+**Incorrect:**
+
+```pony
+match x
+  | let s: String => s
+  | let n: U32 => n.string()
+end
+```
+
+**Correct:**
+
+```pony
+match x
+| let s: String => s
+| let n: U32 => n.string()
+end
+```
+
+## `style/match-no-single-line`
+
+**Default:** on
+
+Match expressions must span multiple lines. A single-line match is harder to scan and usually indicates the expression would be clearer as an `if`/`else` chain.
+
+**Incorrect:**
+
+```pony
+let y = match x | let s: String => s else "" end
+```
+
+**Correct:**
+
+```pony
+let y =
+  match x
+  | let s: String => s
+  else
+    ""
+  end
+```
+
 ## `style/member-naming`
 
 **Default:** on
@@ -164,6 +275,46 @@ my-package/
 ```text
 my_package/
   main.pony
+```
+
+## `style/partial-call-spacing`
+
+**Default:** on
+
+The `?` at partial call sites must immediately follow `)` with no space. This is the opposite convention from method declarations.
+
+**Incorrect:**
+
+```pony
+let x = foo() ?
+let y = bar(1, 2) ?
+```
+
+**Correct:**
+
+```pony
+let x = foo()?
+let y = bar(1, 2)?
+```
+
+## `style/partial-spacing`
+
+**Default:** on
+
+The `?` in partial method declarations must have surrounding spaces. A space is required before `?` and a space or end-of-line after it.
+
+**Incorrect:**
+
+```pony
+class Foo
+  fun bar()? => None
+```
+
+**Correct:**
+
+```pony
+class Foo
+  fun bar() ? => None
 ```
 
 ## `style/public-docstring`


### PR DESCRIPTION
Adds documentation for the 6 new AST-based lint rules from ponylang/ponyc PR #4864:

- `style/blank-lines` — blank line conventions within and between entities
- `style/dot-spacing` — no spaces around `.`; `.>` spaced as infix operator
- `style/match-case-indent` — match case `|` must align with `match` keyword
- `style/match-no-single-line` — match expressions must span multiple lines
- `style/partial-call-spacing` — `?` at call site must immediately follow `)`
- `style/partial-spacing` — `?` in method declaration needs surrounding spaces

Each rule gets a detailed section in the rule reference page with examples, plus a row in the overview table. All default on.

The ponyc PR is still open, so this can be merged when it ships.

Closes #1170