### PR TITLE
Add style/prefer-chaining to lint rule reference

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -44,6 +44,7 @@ pony-lint --version
 | `style/package-naming` | off | Package directory name should be snake_case |
 | `style/partial-call-spacing` | on | `?` at call site must immediately follow `)` |
 | `style/partial-spacing` | on | `?` in method declaration needs surrounding spaces |
+| `style/prefer-chaining` | on | Local variable can be replaced with `.>` chaining |
 | `style/public-docstring` | on | Public types and methods should have a docstring |
 | `style/trailing-whitespace` | on | Trailing spaces or tabs |
 | `style/type-naming` | on | Type names should be CamelCase |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -404,6 +404,35 @@ class Foo
   fun bar() ? => None
 ```
 
+## `style/prefer-chaining`
+
+**Default:** on
+
+Flags patterns where a value is bound to a local variable, methods are called on it repeatedly, and the variable is returned — when `.>` chaining would be cleaner. Triggers on both `let` and `var` bindings with 2 or more consecutive dot-calls followed by a trailing bare reference to the variable.
+
+**Incorrect:**
+
+```pony
+class Foo
+  fun make_list(): Array[U32] =>
+    let r = Array[U32]
+    r.push(1)
+    r.push(2)
+    r.push(3)
+    r
+```
+
+**Correct:**
+
+```pony
+class Foo
+  fun make_list(): Array[U32] =>
+    Array[U32]
+      .> push(1)
+      .> push(2)
+      .> push(3)
+```
+
 ## `style/public-docstring`
 
 **Default:** on


### PR DESCRIPTION
Documents the new `style/prefer-chaining` pony-lint rule added in ponylang/ponyc#4870. Adds the rule to the summary table in `linting.md` and a detailed entry with code examples in `rule-reference.md`.