### PR TITLE
Add Helix project-specific defines configuration

### DIFF
--- a/docs/use/pony-lsp.md
+++ b/docs/use/pony-lsp.md
@@ -49,7 +49,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [language-server.pony-lsp]
 command = "pony-lsp"
-args = [""] 
+args = [""]
 ```
 
 #### Project-Specific Defines


### PR DESCRIPTION
Adds a subsection to the Helix editor configuration documenting how to set up project-specific defines via `.helix/languages.toml`.