### PR TITLE
Document style/assignment-indent lint rule

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -29,6 +29,7 @@ pony-lint --version
 | Rule ID | Default | Description |
 |---------|---------|-------------|
 | `style/acronym-casing` | on | Acronyms in type names should be fully uppercased |
+| `style/assignment-indent` | on | Multiline assignment RHS must start on the line after `=` |
 | `style/blank-lines` | on | Blank line conventions within and between entities |
 | `style/comment-spacing` | on | `//` not followed by exactly one space |
 | `style/docstring-format` | on | Docstring `"""` tokens should be on their own lines |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -24,6 +24,39 @@ class JSONParser
 primitive HTTPMethod
 ```
 
+## `style/assignment-indent`
+
+**Default:** on
+
+When an assignment's right-hand side spans multiple lines, the RHS must start on the line after the `=`, not on the same line. Single-line assignments are not checked.
+
+**Incorrect:**
+
+```pony
+class Foo
+  fun apply(x: U32): U32 =>
+    var y: U32 = if x > 0 then
+      x
+    else
+      U32(0)
+    end
+    y
+```
+
+**Correct:**
+
+```pony
+class Foo
+  fun apply(x: U32): U32 =>
+    var y: U32 =
+      if x > 0 then
+        x
+      else
+        U32(0)
+      end
+    y
+```
+
 ## `style/blank-lines`
 
 **Default:** on


### PR DESCRIPTION
Adds the `style/assignment-indent` rule to the summary table on the linting overview page and to the rule reference page with description and incorrect/correct code examples.

Companion to ponylang/ponyc#4881.