### PR TITLE
Flesh out the Learn section

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -82,10 +82,9 @@ https://ponylang.org/* https://www.ponylang.io/:splat 301!
 /discover/#what-makes-pony-different /discover/what-makes-pony-different 301!
 /discover/#why-pony /discover/why-pony 301!
 
-/learn/ /learn/getting-help/ 307!
 /learn/#getting-help /learn/getting-help/ 301!
 /learn/#installing-pony /learn/installing-pony/ 301!
-/learn/#getting-started /learn/getting-started/ 301!
+/learn/#getting-started /learn/ 301!
 /learn/#reference-capabilities /learn/reference-capabilities/ 301!
 
 /reference/ /reference/debugging/ 307!

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ hide:
 
 An open-source, object-oriented, actor-model, capabilities-secure, high-performance programming language.
 
-[Get Started](learn/getting-started.md){ .md-button .md-button--primary }
+[Get Started](learn/index.md){ .md-button .md-button--primary }
 [Try It in Your Browser](https://playground.ponylang.io/){ .md-button target=_blank }
 [Install](https://github.com/ponylang/ponyc/blob/main/INSTALL.md){ .md-button target=_blank }
 

--- a/docs/learn/getting-started.md
+++ b/docs/learn/getting-started.md
@@ -1,8 +1,0 @@
-# Getting started
-
-We have a couple resources designed to help you learn, we suggest starting with the tutorial and from there, moving on to the Pony Patterns book. Additionally, standard library documentation is available online. The cheat sheet is meant to serve as a quick reference for the main ideas that you'll encounter as you begin to learn Pony.
-
-- [Tutorial](http://tutorial.ponylang.io)
-- [Pony Patterns](http://patterns.ponylang.io) cookbook
-- [Standard library docs](http://stdlib.ponylang.io/)
-- [Cheat Sheet](/media/cheatsheet/pony-cheat-sheet.pdf)

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -1,0 +1,18 @@
+# Learn Pony
+
+New to Pony? Start with [installing Pony](installing-pony.md) and then work
+through the [tutorial](https://tutorial.ponylang.io). The tutorial covers
+the language from the ground up and is the best way to get a feel for how
+Pony works.
+
+Once you're comfortable with the basics, the [Pony Patterns](https://patterns.ponylang.io)
+cookbook and [standard library documentation](https://stdlib.ponylang.io) are
+good next steps. The [cheat sheet](/media/cheatsheet/pony-cheat-sheet.pdf)
+is handy to keep nearby as a quick reference.
+
+[Reference capabilities](reference-capabilities.md) are the concept most
+people struggle with. We have a page dedicated to resources that will help
+you get over that hump.
+
+If you get stuck, don't worry. The Pony community is small but helpful.
+Check out [getting help](getting-help.md) for how to reach us.

--- a/docs/learn/installing-pony.md
+++ b/docs/learn/installing-pony.md
@@ -1,3 +1,29 @@
 # Installing Pony
 
-Ready to dive into Pony? Excellent! Please checkout the [installation instructions](https://github.com/ponylang/ponyc/blob/main/README.md#installation) for the ponyc compiler.
+The easiest way to install Pony is through [ponyup](https://github.com/ponylang/ponyup), Pony's toolchain manager. Ponyup handles installing and updating the Pony compiler and related tools.
+
+## Install ponyup
+
+On Linux or macOS, run:
+
+```bash
+sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)"
+```
+
+## Install the Pony compiler
+
+Once ponyup is installed, install the latest release of the Pony compiler:
+
+```bash
+ponyup update ponyc release
+```
+
+Prebuilt packages are only available for certain platforms. Check the [ponyc INSTALL.md](https://github.com/ponylang/ponyc/blob/main/INSTALL.md) for the current list of supported distributions. If yours isn't listed, you'll need to build from source.
+
+## Additional dependencies
+
+On Linux, the Pony compiler requires a C compiler and may need additional libraries depending on your distribution. See the [ponyc installation instructions](https://github.com/ponylang/ponyc/blob/main/README.md#installation) for distro-specific details.
+
+## More information
+
+See the [ponyup repository](https://github.com/ponylang/ponyup) for full documentation, including how to install nightly builds and manage multiple toolchain versions.

--- a/docs/learn/papers.md
+++ b/docs/learn/papers.md
@@ -1,12 +1,35 @@
 # Papers
 
-If reading academic papers is your thing, you're in luck. There are a number of papers that have been written about Pony. We host a number of them on this website. If you're interested in learning more about "deep Pony", these papers are a great place to start:
+If reading academic papers is your thing, you're in luck. There are a number of papers that have been written about Pony. We host a number of them on this website. If you're interested in learning more about "deep Pony", these papers are a great place to start.
 
-* [Pony: Co-designing a Type System and a Runtime](/media/papers/codesigning.pdf)
-* [Deny Capabilities for Safe, Fast Actors](/media/papers/fast-cheap.pdf)
-* [Ownership and Reference Counting based Garbage Collection in the Actor World](/media/papers/OGC.pdf)
-* [Fully Concurrent Garbage Collection of Actors on Many-Core Machines](/media/papers/opsla237-clebsch.pdf)
-* [A String of Ponies: Transparent Distributed Programming with Actors](/media/papers/a_string_of_ponies.pdf)
-* [A Principled Design of Capabilities in Pony](/media/papers/a_prinicipled_design_of_capabilities_in_pony.pdf)
-* [ORCA: GC and Type System Co-Design for Actor Languages](/media/papers/orca_gc_and_type_system_co-design_for_actor_languages.pdf)
-* [Formalizing Generics for Pony](/media/papers/formalizing-generics-for-pony.pdf)
+## [Pony: Co-designing a Type System and a Runtime](/media/papers/codesigning.pdf)
+
+The best overview paper. Explains how Pony's type system and runtime were designed together so that reference capabilities enable a concurrent garbage collector without stop-the-world pauses.
+
+## [Deny Capabilities for Safe, Fast Actors](/media/papers/fast-cheap.pdf)
+
+Introduces deny capabilities, the formal foundation for Pony's reference capability system. Shows how denying certain operations on a reference (rather than granting them) lets the type system guarantee data-race freedom.
+
+## [A Principled Design of Capabilities in Pony](/media/papers/a_prinicipled_design_of_capabilities_in_pony.pdf)
+
+Extends the deny capabilities work with a more complete formalization. Covers viewpoint adaptation, safe-to-write, and how capabilities compose under aliasing and subtyping.
+
+## [ORCA: GC and Type System Co-Design for Actor Languages](/media/papers/orca_gc_and_type_system_co-design_for_actor_languages.pdf)
+
+Describes Pony's production garbage collector. ORCA uses the type system's knowledge of reference capabilities to do per-actor garbage collection with no stop-the-world pauses and no read or write barriers.
+
+## [Ownership and Reference Counting based Garbage Collection in the Actor World](/media/papers/OGC.pdf)
+
+An earlier take on actor garbage collection that influenced ORCA. Combines ownership tracking with reference counting to collect both objects within an actor and actors themselves.
+
+## [Fully Concurrent Garbage Collection of Actors on Many-Core Machines](/media/papers/opsla237-clebsch.pdf)
+
+Focuses on collecting actors themselves (not just the objects they own) without stopping the world. Covers the protocol for detecting when an actor is unreachable and can be reclaimed.
+
+## [A String of Ponies: Transparent Distributed Programming with Actors](/media/papers/a_string_of_ponies.pdf)
+
+Explores distributing Pony actors across multiple machines. Actors communicate the same way whether local or remote, so distribution is transparent to the programmer.
+
+## [Formalizing Generics for Pony](/media/papers/formalizing-generics-for-pony.pdf)
+
+Covers how generic types interact with reference capabilities. Works through the formalism for constraining type parameters with capabilities and how that affects subtyping.

--- a/docs/learn/watch.md
+++ b/docs/learn/watch.md
@@ -1,0 +1,19 @@
+# Watch
+
+Videos are a great way to get a feel for Pony. Here are some we recommend.
+
+## [Pony: High-Performance, Memory-Safe Actors (Developer Voices)](https://www.youtube.com/watch?v=u9da3UzEhEI)
+
+Sean Allen explains what Pony is, why reference capabilities exist, and how the garbage collector works. Good first video if you want to understand the "why" behind Pony.
+
+## [VUG #11: Pony via a GitHub REST API](https://vimeo.com/592434464)
+
+Sean walks through a real Pony library in progress. Good for seeing what actual Pony code looks like.
+
+## [Learn Pony with Brian and Sean, Episode 1](https://www.youtube.com/watch?v=ODelwNLePRA)
+
+Sean teaches Brian Pony from scratch. Watch someone ask the questions you'll have.
+
+## [Learn Pony with Brian and Sean, Episode 2](https://www.youtube.com/watch?v=wBzPIYgfbdo)
+
+Continuation of the hands-on learning session.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,10 +130,11 @@ theme:
 nav:
   - Home: "index.md"
   - Learn:
-      - Getting Help: "learn/getting-help.md"
+      - Overview: "learn/index.md"
       - Installing Pony: "learn/installing-pony.md"
-      - Getting Started: "learn/getting-started.md"
+      - Getting Help: "learn/getting-help.md"
       - Reference Capabilities: "learn/reference-capabilities.md"
+      - Watch: "learn/watch.md"
       - Papers: "learn/papers.md"
   - Use:
       - Overview: "use/index.md"


### PR DESCRIPTION
The Learn section was the thinnest on the site — 89 lines across 5 files, mostly linking out to external resources. It's the first nav tab after Home and the entry point from the homepage "Get Started" button, but it didn't do much to orient newcomers.

- Add a landing page (`index.md`) with a guided learning path that absorbs the content from `getting-started.md`
- Rewrite `installing-pony.md` around ponyup with actual install commands instead of a one-liner link to the ponyc README
- Add a curated videos page (`watch.md`) with 4 recommended talks
- Delete the now-redundant `getting-started.md`
- Update the homepage "Get Started" button to point to the new landing page
- Fix redirects: remove the `/learn/` redirect (now served by `index.md`), update `/learn/#getting-started` to point to `/learn/`
- Reorder nav: Overview, Installing Pony, Getting Help, Reference Capabilities, Watch, Papers