### PR TITLE
Add control-structure-alignment to linting docs

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -32,6 +32,7 @@ pony-lint --version
 | `style/assignment-indent` | on | Multiline assignment RHS must start on the line after `=` |
 | `style/blank-lines` | on | Blank line conventions within and between entities |
 | `style/comment-spacing` | on | `//` not followed by exactly one space |
+| `style/control-structure-alignment` | on | Control structure keywords must be vertically aligned |
 | `style/docstring-format` | on | Docstring `"""` tokens should be on their own lines |
 | `style/dot-spacing` | on | No spaces around `.`; `.>` spaced as infix operator |
 | `style/file-naming` | on | File name should match principal type |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -117,6 +117,42 @@ Line comments (`//`) must be followed by exactly one space. An empty comment (`/
 let url = "http://example.com" // inside strings is ignored
 ```
 
+## `style/control-structure-alignment`
+
+**Default:** on
+
+Control structure keywords must be vertically aligned. Each keyword in a control structure must start at the same column as the opening keyword. Single-line structures are exempt. The `do` keyword is not checked because it always appears on the same line as its opening keyword.
+
+The following keyword groups are checked:
+
+- `if` / `elseif` / `else` / `end`
+- `ifdef` / `elseif` / `else` / `end`
+- `while` / `else` / `end`
+- `for` / `else` / `end`
+- `try` / `else` / `then` / `end`
+- `repeat` / `until` / `else` / `end`
+- `with` / `end`
+
+**Incorrect:**
+
+```pony
+if condition then
+  do_something()
+    else
+  do_other()
+      end
+```
+
+**Correct:**
+
+```pony
+if condition then
+  do_something()
+else
+  do_other()
+end
+```
+
 ## `style/docstring-format`
 
 **Default:** on


### PR DESCRIPTION
Document the new `style/control-structure-alignment` rule added in ponylang/ponyc#4889. Adds a row to the rules table on the overview page and a full reference entry with keyword groups, exemptions, and incorrect/correct code examples.