### PR TITLE
Update pony-lint docs for type-alias-format and array-literal-format rules

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -29,6 +29,7 @@ pony-lint --version
 | Rule ID | Default | Description |
 |---------|---------|-------------|
 | `style/acronym-casing` | on | Acronyms in type names should be fully uppercased |
+| `style/array-literal-format` | on | Multiline array literal formatting (bracket placement and spacing) |
 | `style/assignment-indent` | on | Multiline assignment RHS must start on the line after `=` |
 | `style/blank-lines` | on | Blank line conventions within and between entities |
 | `style/comment-spacing` | on | `//` not followed by exactly one space |
@@ -51,6 +52,7 @@ pony-lint --version
 | `style/prefer-chaining` | on | Local variable can be replaced with `.>` chaining |
 | `style/public-docstring` | on | Public types and methods should have a docstring |
 | `style/trailing-whitespace` | on | Trailing spaces or tabs |
+| `style/type-alias-format` | on | Multiline type alias formatting (paren placement and spacing) |
 | `style/type-naming` | on | Type names should be CamelCase |
 
 See the [Rule Reference](linting/rule-reference.md) for detailed explanations and code examples for each rule.

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -24,6 +24,51 @@ class JSONParser
 primitive HTTPMethod
 ```
 
+## `style/array-literal-format`
+
+**Default:** on
+
+Checks formatting of multiline array literals. For array literals that span multiple lines:
+
+- The opening `[` must be the first non-whitespace on its line (no hanging indent after `=` or other expression context).
+- A space is required after `[` when there is content on the same line.
+
+Single-line array literals are not checked.
+
+**Incorrect:**
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let ns = [as USize:
+      1
+      2
+    ]
+```
+
+**Correct:**
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let ns =
+      [ as USize:
+        1
+        2 ]
+```
+
+The closing `]` may also be on its own line:
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let ns =
+      [ as USize:
+        1
+        2
+      ]
+```
+
 ## `style/assignment-indent`
 
 **Default:** on
@@ -668,6 +713,71 @@ class Foo
   fun apply(): None =>
     let x = 1
     None
+```
+
+## `style/type-alias-format`
+
+**Default:** on
+
+Checks formatting of multiline type alias declarations. For type aliases with a multiline union or intersection type:
+
+- The opening `(` must be the first non-whitespace on its line (no hanging indent after `is`).
+- A space is required after `(`.
+- For each `|` or `&` that is the first non-whitespace on its line, a space is required after it.
+- A space is required before the closing `)`.
+
+Single-line type aliases and simple aliases (no union/intersection) are not checked. Only `|`/`&` at line starts (first non-whitespace) are checked — mid-line separators in nested types are not.
+
+**Incorrect:**
+
+```pony
+// Hanging indent — ( must be on its own line
+type Signed is (I8
+  | I16
+  | I32 )
+
+// Missing space after (
+type Signed is
+  (I8
+  | I16
+  | I32 )
+
+// Missing space after |
+type Signed is
+  ( I8
+  |I16
+  | I32 )
+
+// Missing space before )
+type Signed is
+  ( I8
+  | I16
+  | I32)
+```
+
+**Correct:**
+
+```pony
+// Single-line — not checked
+type Signed is (I8 | I16 | I32)
+
+// Multiline with ) inline
+type Signed is
+  ( I8
+  | I16
+  | I32 )
+
+// Multiline with ) on its own line
+type Signed is
+  ( I8
+  | I16
+  | I32
+  )
+
+// Intersection type
+type Both is
+  ( Hashable
+  & Stringable )
 ```
 
 ## `style/type-naming`


### PR DESCRIPTION
Add summary table rows in `linting.md` and detailed rule reference sections in `rule-reference.md` for the two new lint rules added in ponylang/ponyc#4890:

- `style/type-alias-format` — checks multiline type alias formatting (paren placement and spacing)
- `style/array-literal-format` — checks multiline array literal formatting (bracket placement and spacing)

Both sections include incorrect/correct code examples derived from the rule implementations and test cases.

Closes #1191