### PR TITLE
Add docs for method-declaration-format and type-parameter-format lint rules

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -44,6 +44,7 @@ pony-lint --version
 | `style/match-case-indent` | on | Match case `\|` must align with `match` keyword |
 | `style/match-no-single-line` | on | Match expressions must span multiple lines |
 | `style/member-naming` | on | Member names should be snake_case |
+| `style/method-declaration-format` | on | Multiline method declaration formatting (parameter layout, return type and `=>` alignment) |
 | `style/operator-spacing` | on | Binary operators need surrounding spaces; no space after unary `-` |
 | `style/package-docstring` | on | Package should have a `<package>.pony` file with a docstring |
 | `style/package-naming` | off | Package directory name should be snake_case |
@@ -54,6 +55,7 @@ pony-lint --version
 | `style/trailing-whitespace` | on | Trailing spaces or tabs |
 | `style/type-alias-format` | on | Multiline type alias formatting (paren placement and spacing) |
 | `style/type-naming` | on | Type names should be CamelCase |
+| `style/type-parameter-format` | on | Multiline type parameter formatting (bracket placement, layout, and `is` alignment) |
 
 See the [Rule Reference](linting/rule-reference.md) for detailed explanations and code examples for each rule.
 

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -467,6 +467,87 @@ class Foo
     None
 ```
 
+## `style/method-declaration-format`
+
+**Default:** on
+
+Checks formatting of multiline method declarations. When a method's parameters span multiple lines, each parameter must be on its own line. When a method declaration spans multiple lines, the return type `:` must be indented one level (2 spaces) from the method keyword, and the `=>` must align with the method keyword. Single-line declarations are not checked.
+
+Applies to `fun`, `new`, and `be` declarations.
+
+**Incorrect:**
+
+```pony
+class Foo
+  fun find(
+    value: U32, offset: USize)
+    : USize
+  =>
+    offset
+```
+
+Two parameters share a line.
+
+```pony
+class Foo
+  fun find(
+    value: U32,
+    offset: USize)
+      : USize
+  =>
+    offset
+```
+
+The `:` is indented too far — it should be at the method keyword's column + 2.
+
+```pony
+class Foo
+  fun find(
+    value: U32,
+    offset: USize)
+    : USize
+    =>
+    offset
+```
+
+The `=>` is indented too far — it should align with `fun`.
+
+**Correct:**
+
+```pony
+class Foo
+  fun find(
+    value: U32,
+    offset: USize)
+    : USize
+  =>
+    offset
+```
+
+```pony
+// Constructor
+class Foo
+  let _x: U32
+  let _y: U32
+
+  new create(
+    x: U32,
+    y: U32)
+  =>
+    _x = x
+    _y = y
+```
+
+```pony
+// Behavior
+actor Foo
+  be apply(
+    x: U32,
+    y: U32)
+  =>
+    None
+```
+
 ## `style/operator-spacing`
 
 **Default:** on
@@ -804,4 +885,74 @@ class FooParser
 primitive _MyHelper
 
 actor SomeActor
+```
+
+## `style/type-parameter-format`
+
+**Default:** on
+
+Checks formatting of multiline type parameter lists. The opening `[` must always be on the same line as the entity or method name. When type parameters span multiple lines, each type parameter must be on its own line. For entities with a provides clause (`is`), the `is` keyword must be indented one level (2 spaces) from the entity keyword when it appears on its own line. Single-line type parameter lists are not checked (except for the `[` same-line requirement, which always applies).
+
+Applies to entities (`class`, `actor`, `primitive`, `struct`, `trait`, `interface`, `type`) and methods (`fun`, `new`, `be`).
+
+**Incorrect:**
+
+```pony
+class Foo
+  [A, B]
+```
+
+The `[` is on a different line than the name.
+
+```pony
+class Foo[
+  A, B,
+  C]
+```
+
+Two type parameters share a line.
+
+```pony
+interface Hashable
+
+class Foo[
+  A,
+  B]
+    is Hashable
+```
+
+The `is` keyword is indented too far — it should be at the entity keyword's column + 2.
+
+**Correct:**
+
+```pony
+// Single-line — not checked
+class Foo[A, B]
+```
+
+```pony
+// Multiline class
+class Foo[
+  A,
+  B]
+```
+
+```pony
+// Entity with provides clause
+interface Hashable
+
+trait Foo[
+  A,
+  B]
+  is Hashable
+```
+
+```pony
+// Method type parameters
+class Foo
+  fun bar[
+    A,
+    B](x: A)
+  =>
+    None
 ```


### PR DESCRIPTION
Adds linting documentation for two new pony-lint rules from ponylang/ponyc#4892:

- `style/method-declaration-format`: checks multiline method declaration formatting (one parameter per line, return type `:` indentation, `=>` alignment)
- `style/type-parameter-format`: checks multiline type parameter formatting (`[` placement, one type parameter per line, `is` alignment)

Both rules get table entries in the linting overview and detailed reference sections with incorrect/correct examples.

Closes #1195