### PR TITLE
Update scheduled and triggered CI job documentation

### DIFF
--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -2,15 +2,28 @@
 
 Across a variety of repositories, we have a number of scheduled CI jobs. This document is an attempt to give a broad overview of what exists and when they run. Please note, this list is not guaranteed to be up-to-date and you should check various repos for final confirmation.
 
-The scheduled jobs list was last updated January 22, 2021.
+The scheduled jobs list was last updated February 28, 2026.
 
 <!-- markdownlint-disable -->
 
-| job | time (utc)  | repo |
+| Job | Time (UTC) | Repo |
 | --- | --- | --- |
-| changelog-tool: nightly build | 00:00 | https://github.com/ponylang/changelog-tool |
-| corral: nightly build | 00:00 | https://github.com/ponylang/corral |
-| ponyc: nightly build | 00:00 | https://github.com/ponylang/ponyc |
-| ponyup: nightly build | 00:00 | https://github.com/ponylang/ponyup |
+| changelog-tool: nightly build | 00:00 | [ponylang/changelog-tool](https://github.com/ponylang/changelog-tool) |
+| corral: nightly build | 00:00 | [ponylang/corral](https://github.com/ponylang/corral) |
+| ponyc: nightly build | 00:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyup: nightly build | 00:00 | [ponylang/ponyup](https://github.com/ponylang/ponyup) |
+| rfc-tool: nightly build | 00:00 | [ponylang/rfc-tool](https://github.com/ponylang/rfc-tool) |
+| ponylang-website: verify site builds | 02:00 | [ponylang/ponylang-website](https://github.com/ponylang/ponylang-website) |
+| pony-patterns: verify site builds | 02:00 | [ponylang/pony-patterns](https://github.com/ponylang/pony-patterns) |
+| pony-tutorial: verify site builds | 02:00 | [ponylang/pony-tutorial](https://github.com/ponylang/pony-tutorial) |
+| ponyc: stress test (Linux TCP open/close) | 05:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Linux ubench) | 05:30 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Windows TCP open/close) | 05:45 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (Windows ubench) | 05:45 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (macOS TCP open/close) | 06:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: stress test (macOS ubench) | 06:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| lori: stress tests | 06:30 | [ponylang/lori](https://github.com/ponylang/lori) |
+| ponyc: test with latest tools | 12:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| pony-sync-helper: post good first issues | 14:00 Mon | [ponylang/pony-sync-helper](https://github.com/ponylang/pony-sync-helper) |
 
 <!-- markdownlint-restore -->

--- a/docs/contribute/ci/triggered-jobs.md
+++ b/docs/contribute/ci/triggered-jobs.md
@@ -2,7 +2,7 @@
 
 Across a variety of repositories, we have a number of CI jobs that get triggered based on events in other repositories. This document is an attempt to give a broad overview of what exists and causes them to run. Please note, this list is not guaranteed to be up-to-date and you should check various repos for final confirmation.
 
-The triggered jobs list was last updated September 14, 2021.
+The triggered jobs list was last updated February 28, 2026.
 
 <!-- markdownlint-disable -->
 
@@ -12,9 +12,20 @@ The triggered jobs list was last updated September 14, 2021.
 
 - [changelog-tool: release](https://github.com/ponylang/changelog-tool/blob/main/.github/workflows/release.yml)
 
-## Triggered workflows
+### Triggered workflows
 
 - [shared-docker: release-a-library-update](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/release-a-library-update.yml)
+
+## ponyc-arm64-macos-nightly-released
+
+### Sending workflows
+
+- [ponyc: cloudsmith-package-synchronised](https://github.com/ponylang/ponyc/blob/main/.github/workflows/cloudsmith-package-sychronised.yml)
+
+### Triggered workflows
+
+- [corral: breakage-against-macos-arm64-ponyc-latest](https://github.com/ponylang/corral/blob/main/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml)
+- [ponyup: breakage-against-macos-arm64-ponyc-latest](https://github.com/ponylang/ponyup/blob/main/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml)
 
 ## ponyc-x86_64-macos-nightly-released
 
@@ -24,32 +35,8 @@ The triggered jobs list was last updated September 14, 2021.
 
 ### Triggered workflows
 
-- [corral breakage-against-macos-arm64-ponyc-latest](https://github.com/ponylang/corral/blob/main/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml)
-- [corral breakage-against-macos-x86-ponyc-latest](https://github.com/ponylang/corral/blob/main/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml)
-- [ponyup: breakage-against-macos-arm64-ponyc-latest](https://github.com/ponylang/ponyup/blob/main/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml)
-- [ponyup: breakage-against-macos-x64-ponyc-latest](https://github.com/ponylang/ponyup/blob/main/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml)
-
-## ponyc-nightly-image-pushed
-
-### Sending workflows
-
-- [ponyc: build-nightly-image](https://github.com/ponylang/ponyc/blob/main/.github/workflows/build-nightly-image.yml)
-
-### Triggered workflows
-
-- [shared-docker: Rebuild ponyc based images](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/rebuild-ponyc-based-images.yml)
-- [shared-docker: release-a-library-update](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/release-a-library-update.yml)
-
-## ponyc-release-image-pushed
-
-### Sending workflows
-
-- [ponyc: build-release-image](https://github.com/ponylang/ponyc/blob/main/.github/workflows/build-release-image.yml)
-
-### Triggered workflows
-
-- [shared-docker: Rebuild ponyc based images](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/rebuild-ponyc-based-images.yml)
-- [shared-docker: release-a-library-update](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/release-a-library-update.yml)
+- [corral: breakage-against-macos-x86-ponyc-latest](https://github.com/ponylang/corral/blob/main/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml)
+- [ponyup: breakage-against-macos-x86-ponyc-latest](https://github.com/ponylang/ponyup/blob/main/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml)
 
 ## ponyc-windows-nightly-released
 
@@ -60,35 +47,66 @@ The triggered jobs list was last updated September 14, 2021.
 ### Triggered workflows
 
 - [corral: breakage-against-windows-ponyc-latest](https://github.com/ponylang/corral/blob/main/.github/workflows/breakage-against-windows-ponyc-latest.yml)
-- [http: breakage-against-windows-ponyc-latest](https://github.com/ponylang/http/blob/main/.github/workflows/breakage-against-windows-ponyc-latest.yml)
 
-## shared-docker-builders-updated
-
-Sent after our various linux builders hosted in the shared-docker repo have been rebuilt.
+## ponyc-nightly-image-pushed
 
 ### Sending workflows
 
-- [shared-docker: Rebuild ponyc based images](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/rebuild-ponyc-based-images.yml)
+- [ponyc: build-nightly-image](https://github.com/ponylang/ponyc/blob/main/.github/workflows/build-nightly-image.yml)
+
+### Triggered workflows
+
+- [library-documentation-action-v2: update-nightly-image](https://github.com/ponylang/library-documentation-action-v2/blob/main/.github/workflows/update-nightly-image.yml)
+- [shared-docker: rebuild-ponyc-based-images](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/rebuild-ponyc-based-images.yml)
+- [shared-docker: release-a-library-update](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/release-a-library-update.yml)
+
+## ponyc-release-image-pushed
+
+### Sending workflows
+
+- [ponyc: build-release-image](https://github.com/ponylang/ponyc/blob/main/.github/workflows/build-release-image.yml)
+
+### Triggered workflows
+
+- [library-documentation-action: update-release-image](https://github.com/ponylang/library-documentation-action/blob/main/.github/workflows/update-release-image.yml)
+- [library-documentation-action-v2: update-release-image](https://github.com/ponylang/library-documentation-action-v2/blob/main/.github/workflows/update-release-image.yml)
+- [shared-docker: rebuild-ponyc-based-images](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/rebuild-ponyc-based-images.yml)
+- [shared-docker: release-a-library-update](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/release-a-library-update.yml)
+
+## shared-docker-builders-updated
+
+Sent after our various Linux builders hosted in the shared-docker repo have been rebuilt.
+
+### Sending workflows
+
+- [shared-docker: rebuild-ponyc-based-images](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/rebuild-ponyc-based-images.yml)
 
 ### Triggered workflows
 
 - [appdirs: breakage-against-ponyc-latest](https://github.com/ponylang/appdirs/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [changelog-tool: breakage-against-ponyc-latest](https://github.com/ponylang/changelog-tool/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [corral: breakage-against-linux-ponyc-latest](https://github.com/ponylang/corral/blob/main/.github/workflows/breakage-against-linux-ponyc-latest.yml)
-- [crypto: breakage-against-ponyc-latest](https://github.com/ponylang/crypto/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
-- [glob: breakage-against-ponyc-latest](https://github.com/ponylang/glob/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [crdt: breakage-against-ponyc-latest](https://github.com/ponylang/crdt/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [fork_join: breakage-against-ponyc-latest](https://github.com/ponylang/fork_join/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [github_rest_api: breakage-against-ponyc-latest](https://github.com/ponylang/github_rest_api/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [hobby: breakage-against-ponyc-latest](https://github.com/ponylang/hobby/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [http: breakage-against-linux-ponyc-latest](https://github.com/ponylang/http/blob/main/.github/workflows/breakage-against-linux-ponyc-latest.yml)
 - [http_server: breakage-against-ponyc-latest](https://github.com/ponylang/http_server/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [json: breakage-against-ponyc-latest](https://github.com/ponylang/json/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [json-ng: breakage-against-ponyc-latest](https://github.com/ponylang/json-ng/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [lori: breakage-against-ponyc-latest](https://github.com/ponylang/lori/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
-- [net_ssl: breakage-against-ponyc-latest](https://github.com/ponylang/net_ssl/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [mare: breakage-against-ponyc-latest](https://github.com/ponylang/mare/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [peg: breakage-against-ponyc-latest](https://github.com/ponylang/peg/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
-- [ponydoc: breakage-against-ponyc-latest](https://github.com/ponylang/ponydoc/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [ponyup: breakage-against-linux-ponyc-latest](https://github.com/ponylang/ponyup/blob/main/.github/workflows/breakage-against-linux-ponyc-latest.yml)
+- [postgres: breakage-against-ponyc-latest](https://github.com/ponylang/postgres/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [reactive_streams: breakage-against-ponyc-latest](https://github.com/ponylang/reactive_streams/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
-- [regex: breakage-against-ponyc-latest](https://github.com/ponylang/regex/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [redis: breakage-against-ponyc-latest](https://github.com/ponylang/redis/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [rfc-tool: breakage-against-ponyc-latest](https://github.com/ponylang/rfc-tool/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [semver: breakage-against-ponyc-latest](https://github.com/ponylang/semver/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
-- [shared-docker: rebuild-ponyc-based-images](https://github.com/ponylang/shared-docker/blob/main/.github/workflows/rebuild-ponyc-based-images.yml)
+- [ssl: breakage-against-ponyc-latest](https://github.com/ponylang/ssl/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [stallion: breakage-against-ponyc-latest](https://github.com/ponylang/stallion/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [uri: breakage-against-ponyc-latest](https://github.com/ponylang/uri/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [valbytes: breakage-against-ponyc-latest](https://github.com/ponylang/valbytes/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [web_link: breakage-against-ponyc-latest](https://github.com/ponylang/web_link/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 
 <!-- markdownlint-restore -->


### PR DESCRIPTION
Rewrites the scheduled jobs and triggered jobs pages under Contribute > Project Operations > CI, which haven't been updated since 2021.

- Scheduled jobs: 4 → 17 entries (added rfc-tool nightly, site verification jobs, ponyc stress tests, latest-tools test, pony-sync-helper weekly job)
- Triggered jobs: added `ponyc-arm64-macos-nightly-released` section (split from x86_64), added `library-documentation-action-v2` receivers, updated `shared-docker-builders-updated` receiver list to reflect current repos
- Fixed heading level inconsistency in triggered-jobs.md
- Improved link formatting in scheduled-jobs.md (bare URLs → markdown links)

Five issues filed for discovered dispatch misconfigurations: ponylang/glob#51, ponylang/regex#63, ponylang/courier#13, ponylang/http#124, ponylang/library-documentation-action#43.

Closes #1196