### PR TITLE
Add style/call-argument-format to linting documentation

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -32,6 +32,7 @@ pony-lint --version
 | `style/array-literal-format` | on | Multiline array literal formatting (bracket placement and spacing) |
 | `style/assignment-indent` | on | Multiline assignment RHS must start on the line after `=` |
 | `style/blank-lines` | on | Blank line conventions within and between entities |
+| `style/call-argument-format` | on | Multiline call argument formatting (argument layout and placement) |
 | `style/comment-spacing` | on | `//` not followed by exactly one space |
 | `style/control-structure-alignment` | on | Control structure keywords must be vertically aligned |
 | `style/docstring-format` | on | Docstring `"""` tokens should be on their own lines |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -140,6 +140,68 @@ class Foo
   fun apply(): U32 => x + y
 ```
 
+## `style/call-argument-format`
+
+**Default:** on
+
+Checks formatting of multiline function call arguments. For calls with two or more positional arguments that span multiple lines:
+
+- No arguments start on the `(` line — arguments should begin on the next line.
+- Arguments are either all on one continuation line, or each on its own line.
+
+Single-line calls, single-argument calls, and named-argument-only calls are not checked. The `where` clause is allowed on its own line and is not subject to layout checks. These rules apply to both regular calls and FFI calls.
+
+**Incorrect:**
+
+```pony
+// Arguments start on the ( line
+foo.bar(U32(1),
+  U32(2), U32(3))
+```
+
+```pony
+// Mixed layout — some args share a line, others don't
+foo.bar(
+  U32(1), U32(2),
+  U32(3))
+```
+
+**Correct:**
+
+```pony
+// Single-line — not checked
+foo.bar(U32(1), U32(2), U32(3))
+```
+
+```pony
+// All on one continuation line
+foo.bar(
+  U32(1), U32(2), U32(3))
+```
+
+```pony
+// Each on its own line
+foo.bar(
+  U32(1),
+  U32(2),
+  U32(3))
+```
+
+```pony
+// Where clause on its own line
+foo.bar(
+  U32(1),
+  U32(2)
+  where y = U32(3))
+```
+
+```pony
+// FFI call — same rules
+@pony_os_errno(
+  U32(1),
+  U32(2))
+```
+
 ## `style/comment-spacing`
 
 **Default:** on


### PR DESCRIPTION
Documents the `style/call-argument-format` lint rule added in ponylang/ponyc#4894. Adds the summary table entry in the linting overview and a full rule reference section with examples covering both violation types (args on `(` line, mixed layout), correct patterns (single-line, all-on-one-line, each-on-own-line), FFI calls, and where-clause usage.

Closes #1199