### PR TITLE
Update Vimeo information to cover both channels

### DIFF
--- a/docs/community/virtual-users-group.md
+++ b/docs/community/virtual-users-group.md
@@ -16,7 +16,7 @@ Have something you'd like to present? Post in the [#virtual users' group](https:
 
 ## Recordings
 
-Past VUG recordings are available on [Vimeo](https://vimeo.com/ponylang). A few highlights:
+Past VUG recordings are available on [Vimeo](https://vimeo.com/channels/ponyvug). A few highlights:
 
 - [An informal tour of the Pony backpressure system](https://vimeo.com/707155973)
 - [Pony vs Rust: How they both drive you mad at compile time](https://vimeo.com/574893226)

--- a/docs/contribute/infrastructure.md
+++ b/docs/contribute/infrastructure.md
@@ -80,7 +80,10 @@ The calendars are owned by the `ponylang.main@gmail.com` account. Calendar feeds
 
 ## Vimeo
 
-The [recordings of our weekly developers' sync](https://vimeo.com/channels/ponydevelopmentsync) are hosted on [Vimeo](https://vimeo.com).
+We use [Vimeo](https://vimeo.com) to host recordings. There are two channels:
+
+- [Pony Development Sync](https://vimeo.com/channels/ponydevelopmentsync) -- weekly sync meeting recordings
+- [Pony Virtual Users' Group](https://vimeo.com/channels/ponyvug) -- VUG talk recordings
 
 The account is owned by Sean T. Allen. Joe McIlvain has an account with upload access. Sean can grant upload access to others as needed.
 


### PR DESCRIPTION
Documents both Vimeo channels (Development Sync and Virtual Users' Group) in the infrastructure page, and fixes the VUG recordings link to point to the dedicated channel URL instead of the general account page.

Closes #956