### PR TITLE
Add FAQ: How do I read console input?

### DIFF
--- a/docs/faq/code.md
+++ b/docs/faq/code.md
@@ -134,3 +134,11 @@ This question usually comes from people accustomed to synchronous calls in other
 The [`counter`](https://github.com/ponylang/ponyc/tree/main/examples/counter) example in `ponylang/ponyc` shows this pattern. `Main` passes `this` to a `Counter` actor, and `Counter` calls `main.display()` with the result.
 
 If you need to coordinate across many actors, the [`ponylang/fork_join`](https://github.com/ponylang/fork_join) library provides a fork-join coordination pattern. For more on asynchronous coordination patterns in general, see the [Actor Promise](https://patterns.ponylang.io/async/actorpromise.html) section of the Pony Patterns book.
+
+## How do I read console input? {:id="console-input"}
+
+There's no blocking `readLine()` call in Pony. All IO is asynchronous. You set up a notifier that gets called when input arrives rather than blocking a thread to wait for it.
+
+The standard library's `term` package provides `Readline` and `ReadlineNotify` for interactive line-oriented input, complete with tab completion and history. The [`readline`](https://github.com/ponylang/ponyc/tree/main/examples/readline) example in `ponylang/ponyc` shows the full pattern.
+
+It's more code than a blocking read in most languages. That's the tradeoff for non-blocking IO.


### PR DESCRIPTION
Pony's async IO model makes interactive console input non-obvious for newcomers. Multiple Zulip threads in #beginner-help ask about this ("Simple IO console example in Pony?", "Simple input handler", "Read linewise from stdin", "stdin reader not exiting").

The answer explains the async callback model and links to the `readline` example in `ponylang/ponyc`.