### PR TITLE
Add missing terms to spellcheck dictionary

### DIFF
--- a/.cspell/pony-terms.txt
+++ b/.cspell/pony-terms.txt
@@ -75,6 +75,7 @@ Drossopoulou's
 dssim
 ECOOP
 Eleskin
+emscripten
 epoll
 equestria
 Erdman
@@ -116,7 +117,10 @@ Hovsäter
 htmlproofer
 httprouter
 Hydraconf
+hyperthreaded
+Hyperthreaded
 hyperthreading
+Hyperthreads
 ibara
 ICFP
 Idris


### PR DESCRIPTION
Adds emscripten, hyperthreaded, and Hyperthreads to the cspell dictionary to clear pre-existing warnings from the FAQ pages.