### PR TITLE
Disable external URL validation in Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,4 @@ ID = "Your_Site_ID"
 [build.environment]
   PYTHON_VERSION = "3.8"
   ENABLED_HTMLPROOFER="false"
+  VALIDATE_EXTERNAL_URLS = "false"


### PR DESCRIPTION
Sets `VALIDATE_EXTERNAL_URLS=false` in the Netlify build environment to prevent spurious build failures from transient network errors and rate limiting by third-party sites.