### PR TITLE
Add llms.txt and llms-full.txt

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,23 @@ plugins:
       categories:
         - categories
         - tags
+  - llmstxt:
+      markdown_description: |
+        Pony is an open-source, object-oriented, actor-model, capabilities-secure,
+        high-performance programming language. This documentation covers learning
+        Pony, using the ecosystem, frequently asked questions, and the philosophy
+        behind the language.
+      full_output: llms-full.txt
+      sections:
+        Learn:
+          - learn/*.md
+        Use:
+          - use/*.md
+          - use/*/*.md
+        FAQ:
+          - faq/*.md
+        Discover:
+          - discover/*.md
 
 theme:
   name: material

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,5 +11,5 @@ ID = "Your_Site_ID"
   command = "mkdocs build"
 
 [build.environment]
-  PYTHON_VERSION = "3.8"
+  PYTHON_VERSION = "3.12"
   ENABLED_HTMLPROOFER="false"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ mkdocs-material==9.7.1
 mkdocs-htmlproofer-plugin>=1.3.0
 mkdocs-ezlinks-plugin>=0.1.8
 mkdocs-rss-plugin>=1.12.1
+mkdocs-llmstxt>=0.5.0
 tzdata>=2024.1


### PR DESCRIPTION
Adds the `mkdocs-llmstxt` plugin so the site generates `/llms.txt` (a Markdown index) and `/llms-full.txt` (all content concatenated) at build time. These files let AI coding assistants ingest the Pony documentation in a single request.

The plugin requires Python >= 3.10, so the Netlify build environment is bumped from 3.8 (EOL) to 3.12.

Sections included: Learn, Use, FAQ, Discover. Blog, Community, Contribute, and Sponsors are excluded as they aren't useful for LLM coding assistance.

Closes #1227