### PR TITLE
Add robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://www.ponylang.io/sitemap.xml


### PR DESCRIPTION
Adds a minimal `robots.txt` pointing to the sitemap. MkDocs copies files from `docs/` to the site root at build time, so it ends up at `/robots.txt`.

Closes #1228