### PR TITLE
Add Building ponyc from Source page

### DIFF
--- a/docs/contribute/developer-resources/arm-development-with-rpi-4.md
+++ b/docs/contribute/developer-resources/arm-development-with-rpi-4.md
@@ -87,4 +87,4 @@ note, this will probably take about 3 hours. make sure you aren't logged out of 
 - `make build -mtune=native`
 - `make test`
 
-See the [ponyc build instructions](https://github.com/ponylang/ponyc/blob/main/BUILD.md) for more information in general about building ponyc.
+See [Building ponyc from Source](building-ponyc-from-source.md) for more information about building ponyc.

--- a/docs/contribute/developer-resources/building-ponyc-from-source.md
+++ b/docs/contribute/developer-resources/building-ponyc-from-source.md
@@ -1,0 +1,174 @@
+# Building ponyc from Source
+
+This page covers building ponyc from source for development and contribution work. For prerequisites and platform-specific dependency installation, see ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md).
+
+## Build Workflow
+
+Building ponyc from source is a multi-stage process:
+
+```bash
+make libs              # Build vendored LLVM (one-time, takes hours)
+make configure         # Configure the CMake build directory
+make build             # Compile ponyc and the runtime
+make test              # Run the test suite
+sudo make install      # Install to /usr/local (or use prefix=/foo)
+```
+
+`make libs` only needs to run once. You'll need to rerun it if the vendored LLVM submodule changes or if you run `make distclean`.
+
+To speed up the LLVM build, pass parallel build flags:
+
+```bash
+make libs build_flags="-j6"
+```
+
+To clean up:
+
+- `make clean` — removes the ponyc build artifacts but keeps the LLVM libraries.
+- `make distclean` — deletes the entire `build` directory, including LLVM. You'll need to rerun `make libs` after this.
+
+## Build Configuration
+
+The main configuration variables are:
+
+| Variable | Default | Description |
+|---|---|---|
+| `config` | `release` | Build type: `release` or `debug` |
+| `arch` | `native` | CPU architecture |
+| `tune` | `generic` | CPU tuning |
+| `build_flags` | `-j2` | Flags passed to the underlying build tool |
+
+Configuration is set at the `make configure` step and carried through to `make build`:
+
+```bash
+make configure config=debug
+make build config=debug
+```
+
+## Compiler Selection
+
+The build system defaults to clang if it's available. To use GCC instead:
+
+```bash
+make configure CC=gcc CXX=g++
+```
+
+The C and C++ compilers must be a matching pair. The build will error if you mix clang with g++ or gcc with clang++.
+
+## Performance Options
+
+### Link-Time Optimization
+
+LTO provides a performance improvement and is worth enabling if you're building ponyc for regular use. It's off by default because it requires clang as the linker — with other linkers, LTO has occasionally produced incorrect binaries. On macOS, an XCode upgrade will require rebuilding ponyc when LTO is enabled.
+
+```bash
+make configure lto=yes
+make build
+```
+
+### Runtime Bitcode
+
+With clang, you can build the Pony runtime as LLVM bitcode. This enables cross-module optimizations between your Pony code and the runtime — essentially "super LTO" for the runtime. Optimization times can be significantly longer.
+
+```bash
+make configure runtime-bitcode=yes
+make build
+```
+
+Then compile programs with:
+
+```bash
+ponyc --runtimebc
+```
+
+## Instrumentation
+
+The `use=` option enables various instrumentation features. It is only valid with `make configure`. Multiple options can be combined with commas:
+
+```bash
+make configure use=address_sanitizer,undefined_behavior_sanitizer
+```
+
+The available options:
+
+| Option | Description |
+|---|---|
+| `valgrind` | Valgrind-aware memory allocator annotations |
+| `address_sanitizer` | Detect buffer overflows, use-after-free |
+| `thread_sanitizer` | Detect data races |
+| `undefined_behavior_sanitizer` | Detect undefined behavior |
+| `dtrace` | USDT probes for DTrace/SystemTap |
+| `systematic_testing` | Deterministic scheduler (requires `scheduler_scaling_pthreads`) |
+| `scheduler_scaling_pthreads` | Pthread-based scheduler scaling |
+| `coverage` | Code coverage instrumentation |
+| `runtimestats` | Runtime statistics collection |
+| `runtimestats_messages` | Runtime statistics with message tracking |
+| `runtime_tracing` | Runtime tracing/profiling |
+| `pooltrack` | Pool memory tracking |
+| `pool_memalign` | Pool allocator with memalign |
+
+For detailed usage of valgrind, sanitizers, DTrace, and systematic testing, see [Custom ponyc Builds](../../use/debugging/custom-ponyc-builds.md).
+
+## IDE Integration
+
+To generate a `compile_commands.json` for clangd and other LSP tools:
+
+```bash
+make configure CMAKE_FLAGS='-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
+```
+
+Then symlink the generated file into the project root:
+
+```bash
+ln -sf build/build_release/compile_commands.json compile_commands.json
+```
+
+Replace `build_release` with `build_debug` if you're using a debug configuration.
+
+## Platform-Specific Notes
+
+### FreeBSD and DragonFly BSD
+
+Use `gmake` instead of `make` for all build commands.
+
+### 32-bit Raspbian
+
+Only GCC works on 32-bit Raspbian — clang is not supported. You also need to override the `tune` option:
+
+```bash
+make libs
+make configure tune=native
+make build
+```
+
+### 64-bit Raspbian
+
+You need to pass `pic_flag=-fPIC` to both the `libs` and `configure` steps, and override the `arch`. The `arch` override is also needed at install time:
+
+```bash
+make libs pic_flag=-fPIC
+make configure arch=armv8-a pic_flag=-fPIC
+make build
+sudo make install arch=armv8-a
+```
+
+### Asahi (M1 Linux)
+
+Override the `arch` option:
+
+```bash
+make libs
+make configure arch=armv8
+make build
+```
+
+## Debugging Tests
+
+The `usedebugger` variable wraps test binaries in a debugger that captures crash information — backtraces, register state, and local variables. This is useful for investigating test failures:
+
+```bash
+make test usedebugger=lldb
+make test usedebugger=gdb
+```
+
+When a test crashes, the debugger runs automatically and prints diagnostic output before exiting with a non-zero status.

--- a/docs/use/debugging/custom-ponyc-builds.md
+++ b/docs/use/debugging/custom-ponyc-builds.md
@@ -36,7 +36,7 @@ make configure use=address_sanitizer,undefined_behavior_sanitizer
 
 Not all combinations are valid — see the individual sections below for compatibility notes.
 
-For full source build instructions (including platform-specific prerequisites), see the [ponyc BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md).
+For full source build instructions (including platform-specific prerequisites), see [Building ponyc from Source](../../contribute/developer-resources/building-ponyc-from-source.md).
 
 ## Valgrind
 

--- a/docs/use/debugging/tracing.md
+++ b/docs/use/debugging/tracing.md
@@ -26,7 +26,7 @@ This is a two step process:
 
     - For Makefile based builds, passing appropriate arguments to the make [invocation](https://github.com/ponylang/ponyc/blob/Makefile)
 
-   There after, we run the [configure command as usual](https://github.com/ponylang/ponyc/blob/main/BUILD.md)
+   There after, we run the [configure command as usual](../../contribute/developer-resources/building-ponyc-from-source.md)
 
 - Build
 

--- a/docs/use/debugging/track-memory-usage.md
+++ b/docs/use/debugging/track-memory-usage.md
@@ -76,7 +76,7 @@ This is a two step process
 
     - For Makefile based builds, passing appropriate arguments to the make [invocation](https://github.com/ponylang/ponyc/blob/Makefile)
 
-   There after, we run the [configure command as usual](https://github.com/ponylang/ponyc/blob/main/BUILD.md)
+   There after, we run the [configure command as usual](../../contribute/developer-resources/building-ponyc-from-source.md)
 
 - Build
 

--- a/docs/use/performance/pony-performance-cheat-sheet.md
+++ b/docs/use/performance/pony-performance-cheat-sheet.md
@@ -517,7 +517,7 @@ Now, warning aside, there's plenty you can learn about tuning your operating sys
 
 ### Build from source {#build-from-source}
 
-The pre-built Pony packages are quite conservative with the optimizations they apply. To get the best performance, you should build your compiler from source. By default, Pony will then take advantage of any features of your CPU like AVX/AVX2. Additionally, you should try building the [runtime as an LLVM bitcode file](https://github.com/ponylang/ponyc#building-the-runtime-as-an-llvm-bitcode-file). Finally, make sure you build a `release` version of the compiler and that your pony binary wasn't compiled with `--debug`.
+The pre-built Pony packages are quite conservative with the optimizations they apply. To get the best performance, you should [build your compiler from source](../../contribute/developer-resources/building-ponyc-from-source.md). By default, Pony will then take advantage of any features of your CPU like AVX/AVX2. Additionally, you should try building the [runtime as an LLVM bitcode file](../../contribute/developer-resources/building-ponyc-from-source.md#runtime-bitcode). Finally, make sure you build a `release` version of the compiler and that your pony binary wasn't compiled with `--debug`.
 
 ### Profile it! {#profiling}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,6 +205,7 @@ nav:
       - Resources:
           - Contributor Zulip Channels: "contribute/zulip-channels.md"
           - Developer Resources:
+              - Building ponyc from Source: "contribute/developer-resources/building-ponyc-from-source.md"
               - Arm Development with RPI 4: "contribute/developer-resources/arm-development-with-rpi-4.md"
               - Performance Testing Setup: "contribute/developer-resources/performance-testing-setup.md"
   - Community:


### PR DESCRIPTION
Adds a "Building ponyc from Source" page under Contribute > Resources > Developer Resources that consolidates build system documentation for contributors. Covers the full build workflow, configuration variables, compiler selection, LTO/runtime-bitcode, all `use=` instrumentation options, IDE integration (`compile_commands.json`), platform-specific notes (FreeBSD, DragonFly, 32/64-bit Raspbian, Asahi), and the `usedebugger` test wrapper.

Updates five existing pages that linked to BUILD.md on GitHub to point to the new page instead, keeping cross-references internal to the site.

Closes #1237