### PR TITLE
Update debugging docs to use current Makefile syntax

### DIFF
--- a/docs/use/debugging/custom-ponyc-builds.md
+++ b/docs/use/debugging/custom-ponyc-builds.md
@@ -124,6 +124,35 @@ The probes are defined under the `pony` provider and cover:
 
 For the full list of probes with parameter types and descriptions, see [`src/common/dtrace_probes.d`](https://github.com/ponylang/ponyc/blob/main/src/common/dtrace_probes.d) in the ponyc source.
 
+## Runtime Statistics
+
+Runtime statistics tracking instruments the Pony runtime to report memory usage per actor and per scheduler thread. This is useful for understanding where memory is going in a running program.
+
+Two options are available:
+
+- `runtimestats` — enables basic runtime statistics
+- `runtimestats_messages` — adds per-message tracking on top of `runtimestats`
+
+For most debugging scenarios, enable both:
+
+```bash
+make configure use=runtimestats,runtimestats_messages
+make build
+```
+
+For details on the available tracking functions and how to call them from Pony code, see [Tracking Memory Usage at Runtime](track-memory-usage.md).
+
+## Runtime Tracing
+
+Runtime tracing records events from the Pony scheduler, actor lifecycle, and message passing. Events can be written to a trace file in the background, or stored in in-memory circular buffers that dump to stderr on abnormal termination (SIGILL, SIGSEGV, SIGBUS). Trace files use Chromium JSON format and can be viewed with [Perfetto](https://perfetto.dev/).
+
+```bash
+make configure use=runtime_tracing
+make build
+```
+
+For details on tracing options and usage, see [Tracing Pony Programs](tracing.md).
+
 ## Systematic Testing
 
 Systematic testing replaces the Pony scheduler with a deterministic, single-threaded scheduler that explores different actor interleaving orders. This is useful for reproducing concurrency bugs that are otherwise non-deterministic.

--- a/docs/use/debugging/tracing.md
+++ b/docs/use/debugging/tracing.md
@@ -14,20 +14,13 @@ Once a trace has been captured, it can be viewed with the [perfetto trace viewer
 
 ## Building ponyc to enable tracing
 
-Tracing is a costly affair and is not enabled by default. Pony runtime needs to be built separately to enable tracing.
+Tracing is not enabled by default. You need to build ponyc from source with the `runtime_tracing` option:
 
-This is a two step process:
+```bash
+make configure use=runtime_tracing
+make build
+```
 
-- Configuring Pony
+The resulting `ponyc` binary is in `build/release/`. Use it in place of your system `ponyc` to compile programs with tracing enabled.
 
-   We need to ensure that at the time of configure step, `-DUSE_RUNTIME_TRACING=true` are passed to the cmake at the configure step.
-
-    - For windows, this implies adding the `-DUSE_RUNTIME_TRACING=true` in the [configure](https://github.com/ponylang/ponyc/blob/make.ps1) section of make.ps1
-
-    - For Makefile based builds, passing appropriate arguments to the make [invocation](https://github.com/ponylang/ponyc/blob/Makefile)
-
-   There after, we run the [configure command as usual](../../contribute/developer-resources/building-ponyc-from-source.md)
-
-- Build
-
-  After the `configure` step we build pony from source as per the platform. We get `ponyc` enabled with tracing in the folder `build/release-runtime_tracing` folder.
+For full source build instructions, see [Custom ponyc Builds for Debugging](custom-ponyc-builds.md).

--- a/docs/use/debugging/track-memory-usage.md
+++ b/docs/use/debugging/track-memory-usage.md
@@ -64,20 +64,13 @@ or,
 
 ### Building ponyc to track memory usage
 
-Tracking memory is a costly affair and is not enabled by default. Pony runtime needs to be built separately to track memory usage.
+Memory tracking is not enabled by default. You need to build ponyc from source with the `runtimestats` and `runtimestats_messages` options:
 
-This is a two step process
+```bash
+make configure use=runtimestats,runtimestats_messages
+make build
+```
 
-- Configuring Pony
+The resulting `ponyc` binary is in `build/release/`. Use it in place of your system `ponyc` to compile programs with memory tracking enabled.
 
-   We need to ensure that at the time of configure step, `-DPONY_USE_MEMTRACK=true -DPONY_USE_MEMTRACK_MESSAGES=true` are passed to the cmake at the configure step.
-
-    - For windows, this implies adding the `-DPONY_USE_MEMTRACK=true -DPONY_USE_MEMTRACK_MESSAGES=true` in the [configure](https://github.com/ponylang/ponyc/blob/make.ps1) section of make.ps1
-
-    - For Makefile based builds, passing appropriate arguments to the make [invocation](https://github.com/ponylang/ponyc/blob/Makefile)
-
-   There after, we run the [configure command as usual](../../contribute/developer-resources/building-ponyc-from-source.md)
-
-- Build
-
-  After the `configure` step we build pony from source as per the platform. We get `ponyc` enabled with tracking memory in the folder `build/release-memtrack_messages` folder.
+For full source build instructions, see [Custom ponyc Builds for Debugging](custom-ponyc-builds.md).


### PR DESCRIPTION
Replaces outdated CMake flags in the track-memory-usage and tracing pages with the current `make configure use=` syntax. The old flags (`-DPONY_USE_MEMTRACK`, `-DPONY_USE_MEMTRACK_MESSAGES`, `-DUSE_RUNTIME_TRACING`) were renamed and are now set via `use=runtimestats,runtimestats_messages` and `use=runtime_tracing` respectively. Also removes references to outdated output directories and Windows-specific make.ps1 instructions.

Adds Runtime Statistics and Runtime Tracing sections to the custom-ponyc-builds reference page so all `use=` options are documented in one place.

Closes #1241