### PR TITLE
Fix duplicated description for ponyint_actor_mem_size

### DIFF
--- a/docs/use/debugging/track-memory-usage.md
+++ b/docs/use/debugging/track-memory-usage.md
@@ -24,7 +24,7 @@ returns the total memory allocated by a scheduler thread.
 
 - `ponyint_actor_mem_size`
 
-returns the size of the given actor.given an actor, this function returns the size of the actor.
+returns the size of the given actor.
 
 - `ponyint_actor_alloc_size`
 


### PR DESCRIPTION
The description for `ponyint_actor_mem_size` on line 27 of `track-memory-usage.md` was accidentally doubled:

> returns the size of the given actor.given an actor, this function returns the size of the actor.

Fixed to just: "returns the size of the given actor."

Closes #1245