### PR TITLE
Reorganize compiler-related docs into Working with the Compiler sections

### DIFF
--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -107,7 +107,7 @@ The available options:
 | `pooltrack` | Pool memory tracking |
 | `pool_memalign` | Pool allocator with memalign |
 
-For detailed usage of valgrind, sanitizers, DTrace, and systematic testing, see [Custom ponyc Builds](../../use/debugging/custom-ponyc-builds.md).
+For detailed usage of valgrind, sanitizers, DTrace, and systematic testing, see [Custom ponyc Builds](../../use/compiler/custom-ponyc-builds.md).
 
 ## IDE Integration
 

--- a/docs/contribute/developer-resources/arm-development-with-rpi-4.md
+++ b/docs/contribute/developer-resources/arm-development-with-rpi-4.md
@@ -87,4 +87,4 @@ note, this will probably take about 3 hours. make sure you aren't logged out of 
 - `make build -mtune=native`
 - `make test`
 
-See [Building ponyc from Source](building-ponyc-from-source.md) for more information about building ponyc.
+See [Building ponyc from Source](../compiler/building-ponyc-from-source.md) for more information about building ponyc.

--- a/docs/use/compiler.md
+++ b/docs/use/compiler.md
@@ -1,0 +1,15 @@
+# Working with the Compiler
+
+This section covers compiler-related topics for Pony users: runtime flags for tuning compiled programs, and building ponyc from source with instrumentation for debugging.
+
+## Runtime Options
+
+Compiled Pony programs accept `--pony*` command-line flags for tuning scheduler threads, garbage collection, the cycle detector, and other runtime behavior. These flags are passed to the compiled binary, not to `ponyc`.
+
+- [Runtime Options](compiler/runtime-options.md)
+
+## Custom ponyc Builds
+
+ponyc can be built from source with instrumentation options for debugging: Valgrind annotations, sanitizers (address, thread, undefined behavior), DTrace/SystemTap probes, and systematic testing for concurrency bugs.
+
+- [Custom ponyc Builds for Debugging](compiler/custom-ponyc-builds.md)

--- a/docs/use/compiler/custom-ponyc-builds.md
+++ b/docs/use/compiler/custom-ponyc-builds.md
@@ -36,7 +36,7 @@ make configure use=address_sanitizer,undefined_behavior_sanitizer
 
 Not all combinations are valid — see the individual sections below for compatibility notes.
 
-For full source build instructions (including platform-specific prerequisites), see [Building ponyc from Source](../../contribute/developer-resources/building-ponyc-from-source.md).
+For full source build instructions (including platform-specific prerequisites), see [Building ponyc from Source](../../contribute/compiler/building-ponyc-from-source.md).
 
 ## Valgrind
 
@@ -140,7 +140,7 @@ make configure use=runtimestats,runtimestats_messages
 make build
 ```
 
-For details on the available tracking functions and how to call them from Pony code, see [Tracking Memory Usage at Runtime](track-memory-usage.md).
+For details on the available tracking functions and how to call them from Pony code, see [Tracking Memory Usage at Runtime](../debugging/track-memory-usage.md).
 
 ## Runtime Tracing
 
@@ -151,7 +151,7 @@ make configure use=runtime_tracing
 make build
 ```
 
-For details on tracing options and usage, see [Tracing Pony Programs](tracing.md).
+For details on tracing options and usage, see [Tracing Pony Programs](../debugging/tracing.md).
 
 ## Systematic Testing
 

--- a/docs/use/compiler/runtime-options.md
+++ b/docs/use/compiler/runtime-options.md
@@ -10,7 +10,7 @@ Run any compiled Pony program with `--ponyhelp` to see the full list of availabl
 
 Use N scheduler threads. Defaults to the number of physical cores (not hyperthreads) available. This can't be larger than the number of cores available.
 
-See the [thread count](pony-performance-cheat-sheet.md#ponythreads) and [thread pinning](pony-performance-cheat-sheet.md#pin-your-threads) sections of the Performance Cheat Sheet for guidance on tuning this value.
+See the [thread count](../performance/pony-performance-cheat-sheet.md#ponythreads) and [thread pinning](../performance/pony-performance-cheat-sheet.md#pin-your-threads) sections of the Performance Cheat Sheet for guidance on tuning this value.
 
 ### `--ponyminthreads`
 
@@ -38,7 +38,7 @@ Do not yield the CPU when no work is available.
 
 Defer garbage collection until an actor is using at least 2^N bytes. Defaults to 2^14 (16 KB).
 
-See the [garbage collector](pony-performance-cheat-sheet.md#garbage-collector) section of the Performance Cheat Sheet for more on GC tuning.
+See the [garbage collector](../performance/pony-performance-cheat-sheet.md#garbage-collector) section of the Performance Cheat Sheet for more on GC tuning.
 
 ### `--ponygcfactor`
 
@@ -54,11 +54,11 @@ Run cycle detection every N milliseconds. Defaults to 100 ms. Min 10 ms, max 100
 
 Do not send block messages to the cycle detector. Setting this to true disables the cycle detector entirely.
 
-See the [cycle detector](pony-performance-cheat-sheet.md#the-dead-actor-collector-ie-cycle-detector) section of the Performance Cheat Sheet for when and why you might want to disable the cycle detector.
+See the [cycle detector](../performance/pony-performance-cheat-sheet.md#the-dead-actor-collector-ie-cycle-detector) section of the Performance Cheat Sheet for when and why you might want to disable the cycle detector.
 
 ## CPU Pinning Options
 
-See the [thread pinning](pony-performance-cheat-sheet.md#pin-your-threads) section of the Performance Cheat Sheet for a detailed walkthrough of CPU pinning with `cset` and `numactl`.
+See the [thread pinning](../performance/pony-performance-cheat-sheet.md#pin-your-threads) section of the Performance Cheat Sheet for a detailed walkthrough of CPU pinning with `cset` and `numactl`.
 
 ### `--ponypin`
 

--- a/docs/use/debugging.md
+++ b/docs/use/debugging.md
@@ -24,4 +24,4 @@ Interested in tracing the execution of a Pony program? Checkout ["Tracing Pony P
 
 ## Custom ponyc Builds
 
-ponyc can be built from source with instrumentation options for debugging: Valgrind annotations, sanitizers (address, thread, undefined behavior), DTrace/SystemTap probes, and systematic testing for concurrency bugs. See [Custom ponyc Builds for Debugging](debugging/custom-ponyc-builds.md).
+ponyc can be built from source with instrumentation options for debugging: Valgrind annotations, sanitizers (address, thread, undefined behavior), DTrace/SystemTap probes, and systematic testing for concurrency bugs. See [Custom ponyc Builds for Debugging](compiler/custom-ponyc-builds.md).

--- a/docs/use/debugging/tracing.md
+++ b/docs/use/debugging/tracing.md
@@ -23,4 +23,4 @@ make build
 
 The resulting `ponyc` binary is in `build/release/`. Use it in place of your system `ponyc` to compile programs with tracing enabled.
 
-For full source build instructions, see [Custom ponyc Builds for Debugging](custom-ponyc-builds.md).
+For full source build instructions, see [Custom ponyc Builds for Debugging](../compiler/custom-ponyc-builds.md).

--- a/docs/use/debugging/track-memory-usage.md
+++ b/docs/use/debugging/track-memory-usage.md
@@ -73,4 +73,4 @@ make build
 
 The resulting `ponyc` binary is in `build/release/`. Use it in place of your system `ponyc` to compile programs with memory tracking enabled.
 
-For full source build instructions, see [Custom ponyc Builds for Debugging](custom-ponyc-builds.md).
+For full source build instructions, see [Custom ponyc Builds for Debugging](../compiler/custom-ponyc-builds.md).

--- a/docs/use/performance.md
+++ b/docs/use/performance.md
@@ -25,7 +25,7 @@ It covers a ton of topics. Some are related to how to design programs for speed.
 
 Compiled Pony programs accept `--pony*` runtime flags for tuning scheduler threads, garbage collection, the cycle detector, and other runtime behavior. These flags are passed to the compiled binary at runtime, not to `ponyc`.
 
-- [Runtime Options](performance/runtime-options.md)
+- [Runtime Options](compiler/runtime-options.md)
 
 ## Performance Testing
 

--- a/docs/use/performance/pony-performance-cheat-sheet.md
+++ b/docs/use/performance/pony-performance-cheat-sheet.md
@@ -517,7 +517,7 @@ Now, warning aside, there's plenty you can learn about tuning your operating sys
 
 ### Build from source {#build-from-source}
 
-The pre-built Pony packages are quite conservative with the optimizations they apply. To get the best performance, you should [build your compiler from source](../../contribute/developer-resources/building-ponyc-from-source.md). By default, Pony will then take advantage of any features of your CPU like AVX/AVX2. Additionally, you should try building the [runtime as an LLVM bitcode file](../../contribute/developer-resources/building-ponyc-from-source.md#runtime-bitcode). Finally, make sure you build a `release` version of the compiler and that your pony binary wasn't compiled with `--debug`.
+The pre-built Pony packages are quite conservative with the optimizations they apply. To get the best performance, you should [build your compiler from source](../../contribute/compiler/building-ponyc-from-source.md). By default, Pony will then take advantage of any features of your CPU like AVX/AVX2. Additionally, you should try building the [runtime as an LLVM bitcode file](../../contribute/compiler/building-ponyc-from-source.md#runtime-bitcode). Finally, make sure you build a `release` version of the compiler and that your pony binary wasn't compiled with `--debug`.
 
 ### Profile it! {#profiling}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,11 +173,13 @@ nav:
               - Pony LLDB Cheat Sheet: "use/debugging/pony-lldb-cheat-sheet.md"
               - Track Memory Usage: "use/debugging/track-memory-usage.md"
               - Trace Pony Programs: "use/debugging/tracing.md"
-              - Custom ponyc Builds: "use/debugging/custom-ponyc-builds.md"
           - Performance:
               - Overview: "use/performance.md"
               - Performance Cheat Sheet: "use/performance/pony-performance-cheat-sheet.md"
-              - Runtime Options: "use/performance/runtime-options.md"
+      - Working with the Compiler:
+          - Overview: "use/compiler.md"
+          - Runtime Options: "use/compiler/runtime-options.md"
+          - Custom ponyc Builds: "use/compiler/custom-ponyc-builds.md"
       - Ecosystem:
           - Packages: "use/packages.md"
       - Build and Release Tools: "use/build-and-release-tools.md"
@@ -193,6 +195,8 @@ nav:
           - Issue and PR Labels: "contribute/labels.md"
           - RFC Process: "contribute/rfcs.md"
           - Releases: "contribute/releases.md"
+      - Working with the Compiler:
+          - Building ponyc from Source: "contribute/compiler/building-ponyc-from-source.md"
       - Project Operations:
           - CI:
               - Overview: "contribute/ci.md"
@@ -206,7 +210,6 @@ nav:
       - Resources:
           - Contributor Zulip Channels: "contribute/zulip-channels.md"
           - Developer Resources:
-              - Building ponyc from Source: "contribute/developer-resources/building-ponyc-from-source.md"
               - Arm Development with RPI 4: "contribute/developer-resources/arm-development-with-rpi-4.md"
               - Performance Testing Setup: "contribute/developer-resources/performance-testing-setup.md"
   - Community:


### PR DESCRIPTION
Issue #1238 proposed grouping compiler-related pages under "Working with the Compiler" in both Use and Contribute. The sub-issues (#1235, #1236, #1237) landed the content but placed pages in existing sections (Performance, Debugging, Developer Resources). This moves them into their own sections as originally proposed.

**Use > Working with the Compiler** (new section between Development and Ecosystem):
- Overview page with brief descriptions and links
- Runtime Options (moved from Performance)
- Custom ponyc Builds (moved from Debugging)

**Contribute > Working with the Compiler** (new section between Workflow and Project Operations):
- Building ponyc from Source (moved from Developer Resources)

All internal cross-references updated for the new paths. `mkdocs build --strict` passes clean.

Closes #1238