### PR TITLE
Fix "discover" warning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,10 @@ repo_url: https://github.com/ponylang/ponyc
 site_url: https://www.ponylang.io/
 use_directory_urls: !ENV [USE_DIRECTORY_URLS, true]
 
+not_in_nav: |
+  discover/**
+  sponsors/**
+
 extra:
   generator: false
   social:


### PR DESCRIPTION
The discover and sponsors pages were intentionally removed from nav as part of the site reorganization (#1152) but the files still exist and are linked from the homepage and footer. mkdocs warns about files not in nav — `not_in_nav` tells it these exclusions are intentional.

Closes #1225