### PR TITLE
Document running pony-lint under corral

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -24,6 +24,16 @@ pony-lint --config .pony-lint.json
 pony-lint --version
 ```
 
+## Using with Corral
+
+For projects that use [corral](https://github.com/ponylang/corral) for dependency management, run pony-lint through `corral run` so that dependencies are on the package search path:
+
+```bash
+corral run -- pony-lint
+
+corral run -- pony-lint src/ test/
+```
+
 ## Rules
 
 | Rule ID | Default | Description |


### PR DESCRIPTION
Add a "Using with Corral" section to the linting docs explaining that projects with dependencies managed by corral should run pony-lint via `corral run`. This matches the same pattern already used on the documentation generation page.