### PR TITLE
Add dedicated 'Getting pony-lsp' section to pony-lsp docs

### DIFF
--- a/docs/use/pony-lsp.md
+++ b/docs/use/pony-lsp.md
@@ -1,8 +1,12 @@
 # Pony Language Server
 
-pony-lsp is the Pony Language Server. It communicates with editors via stdout/stdin using the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/). It is part of the [ponylang/ponyc](https://github.com/ponylang/ponyc) repository, built alongside the compiler, and distributed with it. Installing ponyc from source or via [ponyup](https://github.com/ponylang/ponyup) will include pony-lsp.
+pony-lsp is the Pony Language Server. It communicates with editors via stdout/stdin using the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/). It is part of the [ponylang/ponyc](https://github.com/ponylang/ponyc) repository, built alongside the compiler.
 
 Your editor launches the `pony-lsp` binary as a subprocess. See the [editor configuration](#editor-configuration) section for setup instructions.
+
+## Getting pony-lsp
+
+`pony-lsp` is distributed via [ponyup](https://github.com/ponylang/ponyup) alongside `ponyc`. Installing a recent `ponyc` will also install `pony-lsp`. See the [ponyc installation instructions](https://github.com/ponylang/ponyc/blob/main/INSTALL.md) for details.
 
 ## Feature Support
 


### PR DESCRIPTION
### Context

The opening paragraph of the `pony-lsp` page conflates what pony-lsp is with how to get it. Separating these concerns makes the page easier to scan.

### Changes

Extracts the installation note from the opening paragraph into a new "Getting pony-lsp" section. The intro paragraph now focuses solely on what `pony-lsp` is and how it communicates with editors.

<img width="715" height="395" alt="image" src="https://github.com/user-attachments/assets/91248ef9-66cc-443c-87b2-ab1d737ac24a" />
