### PR TITLE
Update method name mangling docs for trace-kind characters

### DIFF
--- a/docs/use/debugging/pony-lldb-cheat-sheet.md
+++ b/docs/use/debugging/pony-lldb-cheat-sheet.md
@@ -188,7 +188,7 @@ You can adjust the type (`long`) to appropriately print the types that correspon
 ### Method Name Mangling
 
 !!! warning "Future breakage possible!"
-    While currently necessary for some debugging, you should know that name mangling might change in the future. Do not depend on this remaining static.
+    While currently necessary for some debugging, you should know that name mangling might change in the future. Do not depend on this remaining static. The information below is accurate as of March 11, 2026.
 
 Method names get mangled by the compiler. The general format for the mangling is:
 


### PR DESCRIPTION
ponyc PR #4944 added trace-kind characters to mangled names for behaviors and constructors, fixing a memory leak when capabilities differ between a trait and its concrete implementation. This updates the LLDB cheat sheet's method name mangling section to document the new format.

Changes:
- Explain that behaviors and constructors include trace-kind characters before each parameter's type character, while functions do not
- Add a trace-kind character table (mutable, immutable, opaque, primitive, compound/unknown)
- Add examples showing the difference between behavior and function mangling