### PR TITLE
Document ponyc tier 3 CI

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -1,6 +1,6 @@
 # ponyc CI Tiers
 
-ponyc organizes its PR CI into two tiers to balance fast feedback against comprehensive coverage.
+ponyc organizes its CI into three tiers to balance fast feedback against comprehensive coverage.
 
 ## Tier 1
 
@@ -26,3 +26,12 @@ Tier 2 jobs are expensive and rarely catch issues that Tier 1 misses. They run o
 - Sanitizers (address sanitizer, undefined behavior sanitizer)
 
 Tier 2 jobs are defined in the [ponyc-tier2](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier2.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.
+
+## Tier 3
+
+Tier 3 jobs test platforms where ponyc support is maintained on a best-effort basis. They run on a weekly schedule (Saturday 3 AM UTC), gated on whether there were commits in the last 7 days. These platforms run in QEMU-based VMs via `cross-platform-actions/action`.
+
+- x86-64 FreeBSD 14.3
+- x86-64 FreeBSD 15.0
+
+Tier 3 jobs are defined in the [ponyc-tier3](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier3.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.

--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -12,6 +12,7 @@ The scheduled jobs list was last updated March 7, 2026.
 | corral: nightly build | 00:00 | [ponylang/corral](https://github.com/ponylang/corral) |
 | ponyc: nightly build | 00:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: Tier 2 CI | 01:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: Tier 3 CI | 03:00 Sat | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyup: nightly build | 00:00 | [ponylang/ponyup](https://github.com/ponylang/ponyup) |
 | rfc-tool: nightly build | 00:00 | [ponylang/rfc-tool](https://github.com/ponylang/rfc-tool) |
 | ponylang-website: verify site builds | 02:00 | [ponylang/ponylang-website](https://github.com/ponylang/ponylang-website) |


### PR DESCRIPTION
Documents the new ponyc tier 3 CI in both the CI tiers page and the scheduled jobs table.

Tier 3 covers platforms where ponyc support is maintained on a best-effort basis, running weekly (Saturday 3 AM UTC) in QEMU-based VMs. Currently FreeBSD 14.3 and 15.0, with OpenBSD and DragonFly planned as future additions.

Companion to ponylang/ponyc#4956 which adds the workflow itself.