### PR TITLE
Update CI tiers docs for arm64 tier changes and weekly checks

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -1,16 +1,14 @@
 # ponyc CI Tiers
 
-ponyc organizes its CI into three tiers to balance fast feedback against comprehensive coverage.
+ponyc organizes its CI into three tiers to balance fast feedback against comprehensive coverage. There's also a set of weekly checks that exist outside the tier system.
 
 ## Tier 1
 
 Tier 1 jobs run on every non-draft PR. These are the primary platforms that most users target and where regressions are most likely to be caught. A PR must pass all Tier 1 jobs before merging.
 
 - x86-64 Linux (glibc and musl)
-- arm64 Linux (glibc and musl)
 - arm64 macOS
 - x86-64 Windows
-- arm64 Windows
 
 Tier 1 jobs are defined in the [pr-ponyc](https://github.com/ponylang/ponyc/blob/main/.github/workflows/pr-ponyc.yml) workflow.
 
@@ -18,20 +16,29 @@ Tier 1 jobs are defined in the [pr-ponyc](https://github.com/ponylang/ponyc/blob
 
 Tier 2 jobs are expensive and rarely catch issues that Tier 1 misses. They run on a daily schedule (1 AM UTC) rather than on every PR, gated on whether there were commits in the last 24 hours.
 
+- arm64 Linux (glibc and musl)
+- arm64 Windows
 - x86-64 macOS
 - `riscv64` Linux (cross-compiled)
 - arm Linux (cross-compiled)
 - armhf Linux (cross-compiled)
-- Use directive variants (`dtrace`, `pool_memalign`, `pool_retain`, `runtimestats`, `runtime_tracing`)
-- Sanitizers (address sanitizer, undefined behavior sanitizer)
 
 Tier 2 jobs are defined in the [ponyc-tier2](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier2.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.
 
 ## Tier 3
 
-Tier 3 jobs test platforms where ponyc support is maintained on a best-effort basis. They run on a weekly schedule (Saturday 3 AM UTC), gated on whether there were commits in the last 7 days. These platforms run in QEMU-based VMs via `cross-platform-actions/action`.
+Tier 3 jobs test platforms where ponyc support is maintained on a best-effort basis. They run on a weekly schedule (Saturday 3 AM UTC), gated on whether there were commits in the last 7 days. These platforms run in QEMU-based VMs.
 
 - x86-64 FreeBSD 14.3
 - x86-64 FreeBSD 15.0
 
 Tier 3 jobs are defined in the [ponyc-tier3](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier3.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.
+
+## Weekly Checks
+
+Weekly checks build and test with non-default compiler directives and sanitizers. They're valuable for catching breakage in code paths that don't get exercised during normal builds, but they rarely surface issues beyond confirming that nothing has been broken. They run on a weekly schedule (Sunday 3 AM UTC), gated on whether there were commits in the last 7 days.
+
+- Use directive variants (`dtrace`, `pool_memalign`, `pool_retain`, `runtimestats`, `runtime_tracing`)
+- Sanitizers (address sanitizer, undefined behavior sanitizer)
+
+Weekly checks are defined in the [ponyc-weekly-checks](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-weekly-checks.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.

--- a/docs/contribute/ci/scheduled-jobs.md
+++ b/docs/contribute/ci/scheduled-jobs.md
@@ -13,6 +13,7 @@ The scheduled jobs list was last updated March 7, 2026.
 | ponyc: nightly build | 00:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: Tier 2 CI | 01:00 | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyc: Tier 3 CI | 03:00 Sat | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
+| ponyc: Weekly Checks | 03:00 Sun | [ponylang/ponyc](https://github.com/ponylang/ponyc) |
 | ponyup: nightly build | 00:00 | [ponylang/ponyup](https://github.com/ponylang/ponyup) |
 | rfc-tool: nightly build | 00:00 | [ponylang/rfc-tool](https://github.com/ponylang/rfc-tool) |
 | ponylang-website: verify site builds | 02:00 | [ponylang/ponylang-website](https://github.com/ponylang/ponylang-website) |


### PR DESCRIPTION
Companion to ponylang/ponyc#4961.

arm64 Linux (glibc and musl) and arm64 Windows moved from tier 1 to tier 2. The use directive and sanitizer jobs moved out of tier 2 into a new weekly checks workflow that runs Sunday 3 AM UTC.

Also fixes a stale reference to `cross-platform-actions/action` in the tier 3 description — FreeBSD CI uses manual QEMU now.