### PR TITLE
Update docs for OpenBSD as a tier 3 platform

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -31,6 +31,7 @@ Tier 3 jobs test platforms where ponyc support is maintained on a best-effort ba
 
 - x86-64 FreeBSD 14.3
 - x86-64 FreeBSD 15.0
+- x86-64 OpenBSD 7.8
 
 Tier 3 jobs are defined in the [ponyc-tier3](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier3.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.
 

--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -127,9 +127,9 @@ Replace `build_release` with `build_debug` if you're using a debug configuration
 
 ## Platform-Specific Notes
 
-### FreeBSD and DragonFly BSD
+### FreeBSD, OpenBSD, and DragonFly BSD
 
-Use `gmake` instead of `make` for all build commands.
+Use `gmake` instead of `make` for all build commands. On OpenBSD, use `doas` instead of `sudo` for installation.
 
 ### 32-bit Raspbian
 


### PR DESCRIPTION
ponylang/ponyc#5003 adds OpenBSD 7.8 as a tier 3 CI target. This updates the website docs to match:

- Add OpenBSD 7.8 to the tier 3 list in the CI tiers doc
- Include OpenBSD in the BSD platform notes for building from source, with a note about `doas` vs `sudo`