### PR TITLE
Document safety/exhaustive-match lint rule

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -38,6 +38,7 @@ corral run -- pony-lint src/ test/
 
 | Rule ID | Default | Description |
 |---------|---------|-------------|
+| `safety/exhaustive-match` | on | Exhaustive `match` should use `\exhaustive\` annotation |
 | `style/acronym-casing` | on | Acronyms in type names should be fully uppercased |
 | `style/array-literal-format` | on | Multiline array literal formatting (bracket placement and spacing) |
 | `style/assignment-indent` | on | Multiline assignment RHS must start on the line after `=` |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -2,6 +2,54 @@
 
 Each rule is listed with its default status, a description of what it checks, and examples of incorrect and correct code.
 
+## `safety/exhaustive-match`
+
+**Default:** on
+
+Flags `match` expressions where the compiler has determined all cases are covered but the `\exhaustive\` annotation is missing. Without `\exhaustive\`, adding a new variant to a union type compiles silently — the compiler injects `else None` for the missing case instead of raising an error. Adding the annotation makes the compiler error when a case is missing.
+
+This rule requires type information, so pony-lint compiles the source through `PassExpr` before checking.
+
+**Incorrect:**
+
+```pony
+type Color is (Red | Green | Blue)
+
+primitive Red
+primitive Green
+primitive Blue
+
+class Foo
+  fun name(color: Color): String =>
+    match color
+    | Red => "red"
+    | Green => "green"
+    | Blue => "blue"
+    end
+```
+
+All cases are handled, but without `\exhaustive\`, adding a `Yellow` variant to `Color` would compile silently with an implicit `else None`.
+
+**Correct:**
+
+```pony
+type Color is (Red | Green | Blue)
+
+primitive Red
+primitive Green
+primitive Blue
+
+class Foo
+  fun name(color: Color): String =>
+    match \exhaustive\ color
+    | Red => "red"
+    | Green => "green"
+    | Blue => "blue"
+    end
+```
+
+With `\exhaustive\`, adding a `Yellow` variant to `Color` without adding a corresponding case produces a compiler error.
+
 ## `style/acronym-casing`
 
 **Default:** on


### PR DESCRIPTION
Adds documentation for the new `safety/exhaustive-match` pony-lint rule being added in ponylang/ponyc#4993. This is the first rule in the new `safety` category.

- Adds a row to the rules summary table in `linting.md`
- Adds a detailed rule reference entry in `rule-reference.md` with incorrect/correct examples