### PR TITLE
Add DragonFly BSD 6.4.2 to tier 3 CI docs

### DIFF
--- a/docs/contribute/ci/ponyc-ci-tiers.md
+++ b/docs/contribute/ci/ponyc-ci-tiers.md
@@ -32,6 +32,7 @@ Tier 3 jobs test platforms where ponyc support is maintained on a best-effort ba
 - x86-64 FreeBSD 14.3
 - x86-64 FreeBSD 15.0
 - x86-64 OpenBSD 7.8
+- x86-64 DragonFly BSD 6.4.2
 
 Tier 3 jobs are defined in the [ponyc-tier3](https://github.com/ponylang/ponyc/blob/main/.github/workflows/ponyc-tier3.yml) workflow. They can also be triggered manually via workflow dispatch with a `ref` input to test a specific branch, tag, or SHA on demand.
 

--- a/docs/contribute/compiler/building-ponyc-from-source.md
+++ b/docs/contribute/compiler/building-ponyc-from-source.md
@@ -131,6 +131,8 @@ Replace `build_release` with `build_debug` if you're using a debug configuration
 
 Use `gmake` instead of `make` for all build commands. On OpenBSD, use `doas` instead of `sudo` for installation.
 
+On DragonFly BSD, the base compiler (GCC 8.3) cannot build the vendored LLVM. Install `gcc13` from packages and pass `CC=/usr/local/bin/gcc13 CXX=/usr/local/bin/g++13` to all `gmake` commands. See ponyc's [BUILD.md](https://github.com/ponylang/ponyc/blob/main/BUILD.md#dragonfly) for full instructions.
+
 ### 32-bit Raspbian
 
 Only GCC works on 32-bit Raspbian — clang is not supported. You also need to override the `tune` option:


### PR DESCRIPTION
Adds DragonFly BSD 6.4.2 to the tier 3 platform list and notes the gcc13 requirement in the building-from-source page.

Companion to ponylang/ponyc#5009.