### PR TITLE
Update actions/checkout from v4.1.1 to v6.0.2

### DIFF
--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check workflow files
         uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Lint codebase
         uses: docker://github/super-linter:v3.8.3
         env:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check spelling
         # streetsidesoftware/cspell-action v8.2.0
         uses: streetsidesoftware/cspell-action@d5d910b521ad408f1e7383c24609079f5a88bdca

--- a/.github/workflows/validate-site-on-pr.yml
+++ b/.github/workflows/validate-site-on-pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Build site

--- a/.github/workflows/verify-site-builds.yml
+++ b/.github/workflows/verify-site-builds.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Build site


### PR DESCRIPTION
Node 20 reaches EOL in April 2026 and GitHub will force Node 24 after June 2, 2026. v6 already uses Node 24 natively.