### PR TITLE
Remove deprecated ponylang/json from docs

### DIFF
--- a/docs/contribute/ci/triggered-jobs.md
+++ b/docs/contribute/ci/triggered-jobs.md
@@ -92,7 +92,6 @@ Sent after our various Linux builders hosted in the shared-docker repo have been
 - [hobby: breakage-against-ponyc-latest](https://github.com/ponylang/hobby/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [http: breakage-against-linux-ponyc-latest](https://github.com/ponylang/http/blob/main/.github/workflows/breakage-against-linux-ponyc-latest.yml)
 - [http_server: breakage-against-ponyc-latest](https://github.com/ponylang/http_server/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
-- [json: breakage-against-ponyc-latest](https://github.com/ponylang/json/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [json-ng: breakage-against-ponyc-latest](https://github.com/ponylang/json-ng/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [lori: breakage-against-ponyc-latest](https://github.com/ponylang/lori/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [mare: breakage-against-ponyc-latest](https://github.com/ponylang/mare/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)

--- a/docs/use/packages.md
+++ b/docs/use/packages.md
@@ -71,12 +71,6 @@ The client is built on [lori](https://github.com/ponylang/lori) and supports str
 
 ## Data Formats and Parsing
 
-### [json](https://github.com/ponylang/json)
-
-A JSON package for Pony.
-
-The package provides `JsonDoc` for parsing and serializing JSON, with `JsonObject`, `JsonArray`, and the `JsonType` union covering all JSON value types. JSON integers (no decimal point) become `I64`; numbers with a fractional part or exponent become `F64`. Building JSON is done by mutating `JsonObject.data` and `JsonArray.data` directly, then calling `string()` to serialize. A `JsonExtractor` class offers chainable navigation for drilling into parsed structures — convenient for reading, though not recommended in hot paths. To send parsed JSON between actors, wrap the parse call in a `recover` block to produce a `val` or `iso` reference.
-
 ### [peg](https://github.com/ponylang/peg)
 
 A parsing expression grammar package for Pony.


### PR DESCRIPTION
The json package has been deprecated. Remove it from the packages page and the CI triggered jobs list.