### PR TITLE
Add livery to triggered jobs documentation

### DIFF
--- a/docs/contribute/ci/triggered-jobs.md
+++ b/docs/contribute/ci/triggered-jobs.md
@@ -92,6 +92,7 @@ Sent after our various Linux builders hosted in the shared-docker repo have been
 - [hobby: breakage-against-ponyc-latest](https://github.com/ponylang/hobby/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [http: breakage-against-linux-ponyc-latest](https://github.com/ponylang/http/blob/main/.github/workflows/breakage-against-linux-ponyc-latest.yml)
 - [http_server: breakage-against-ponyc-latest](https://github.com/ponylang/http_server/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
+- [livery: breakage-against-ponyc-latest](https://github.com/ponylang/livery/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [lori: breakage-against-ponyc-latest](https://github.com/ponylang/lori/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [mare: breakage-against-ponyc-latest](https://github.com/ponylang/mare/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)
 - [peg: breakage-against-ponyc-latest](https://github.com/ponylang/peg/blob/main/.github/workflows/breakage-against-ponyc-latest.yml)


### PR DESCRIPTION
Add livery's breakage-against-ponyc-latest workflow to the shared-docker-builders-updated section of the triggered jobs documentation.