### PR TITLE
Replace Development blog category with Libraries and Engineering

### DIFF
--- a/docs/blog/posts/pony-gets-a-new-json-library.md
+++ b/docs/blog/posts/pony-gets-a-new-json-library.md
@@ -4,7 +4,7 @@ title: "Pony Gets a New JSON Library"
 authors:
   - seantallen
 categories:
-  - Development
+  - Libraries
 draft: false
 ---
 

--- a/docs/blog/posts/pony-networking-take-two.md
+++ b/docs/blog/posts/pony-networking-take-two.md
@@ -4,7 +4,7 @@ title: "Pony Networking, Take Two"
 authors:
   - seantallen
 categories:
-  - Development
+  - Libraries
 draft: false
 ---
 

--- a/docs/blog/posts/stallion-http-server.md
+++ b/docs/blog/posts/stallion-http-server.md
@@ -4,7 +4,7 @@ title: "Stallion: An HTTP Server Built Different"
 authors:
   - seantallen
 categories:
-  - Development
+  - Libraries
 draft: false
 ---
 

--- a/docs/blog/posts/teaching-claude-to-write-pony.md
+++ b/docs/blog/posts/teaching-claude-to-write-pony.md
@@ -4,7 +4,7 @@ title: "Teaching Claude to Write Pony"
 authors:
   - seantallen
 categories:
-  - Development
+  - Engineering
 draft: false
 ---
 


### PR DESCRIPTION
Development was too broad a bucket. Libraries is for posts about specific library work (json, lori, stallion, templates). Engineering is for broader posts about working with Pony (teaching Claude, persistent data structures).

Future posts about ponyc internals can use a ponyc category, runtime posts can use Runtime, etc.

Also pushed category updates to the two open blog post PRs:
- #1281 (template engine) → Libraries
- #1224 (persistent data structures) → Engineering