### PR TITLE
Clarify that Items of Note is the default LWIP section

### DIFF
--- a/.claude/skills/lwip/SKILL.md
+++ b/.claude/skills/lwip/SKILL.md
@@ -8,6 +8,24 @@ Create a new "Last Week in Pony" blog post.
 
 ## Additional Notes
 
+- **Most items go under `## Items of Note`** as `###` subsections. Top-level
+  `##` sections are reserved for highlighted items only. The default home for
+  any item is Items of Note — only promote to `##` when there's a specific
+  reason. Things that warrant highlighting:
+  - Changes in Pony team membership (new committers, new core team members,
+    departures).
+  - Libraries with a 0.1.0 release — describe what the library provides and
+    why you'd want it. Don't cover libraries that haven't had a first release
+    yet.
+  - Major version bumps (1.0.0, 2.0.0, etc.) — cover what changed and why it
+    matters.
+  - Items explicitly flagged for highlighting in the issue comments.
+- New library sections should be feature overviews, not per-version
+  changelogs. When a library has multiple releases in one week, describe
+  what it does as a whole. Don't enumerate what changed in each version.
+- Describe libraries from the user's perspective. Focus on what it does for
+  them (features, protocol support, API surface), not project-internal
+  motivations (why it was built, what larger effort it's part of).
 - When referring to repos by short name in prose (not `owner/repo` format),
   use lowercase to match the actual repo name: `ponyc`, `corral`, `ponyup`,
   not `Ponyc`, `Corral`, `Ponyup`.
@@ -17,19 +35,6 @@ Create a new "Last Week in Pony" blog post.
 - Link targets should match what the link text describes. Don't link "Homebrew
   formula" to a Zulip thread about the formula — either link to the formula
   itself or use plain text.
-- Changes in Pony team membership (new committers, new core team members,
-  departures) always get prominent `##` sections near the top of the post.
-- Libraries with a 0.1.0 release get their own `##` section describing what
-  the library provides and why you'd want it. Don't cover libraries that
-  haven't had a first release yet.
-- New library sections should be feature overviews, not per-version
-  changelogs. When a library has multiple releases in one week, describe
-  what it does as a whole. Don't enumerate what changed in each version.
-- Describe libraries from the user's perspective. Focus on what it does for
-  them (features, protocol support, API surface), not project-internal
-  motivations (why it was built, what larger effort it's part of).
-- Major version bumps (1.0.0, 2.0.0, etc.) also get their own `##` section
-  covering what changed and why it matters.
 - Be frugal with em dashes. A few per post is fine, but heavy use reads as
   AI-generated. Prefer periods, commas, colons, or parentheses when they
   work just as well.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,11 @@ date: YYYY-MM-DDTHH:MM:SS-04:00
 
 1. Opening hook — 1-2 sentences, conversational, teasing what's in the post
 2. `<!-- more -->` marker
-3. `##` sections for noteworthy items (important releases, announcements, etc.)
-4. `## Items of Note` with `###` subsections (Office Hours, Pony Development
-   Sync, community items)
+3. `##` sections for highlighted items only (see the lwip skill for what
+   qualifies — most items do not)
+4. `## Items of Note` with `###` subsections — the default home for most
+   content (community items, routine releases, Office Hours, Pony Development
+   Sync, etc.)
 5. `## Releases` — bullet list of all releases with links, format:
    `- [org/repo version](release-url)`
 6. `---` separator
@@ -80,9 +82,12 @@ Got something you think should be featured? There's a GitHub issue for that! Add
 
 Releases always appear in the `## Releases` bullet list. When a release has
 noteworthy content (bug fixes affecting users, new features, breaking changes),
-it also gets its own `##` section higher in the post with a short write-up.
-Read the release notes to determine if a release warrants its own section. Use
-judgment — routine releases with nothing interesting just go in the list.
+it also gets a `###` subsection under `## Items of Note` with a short
+write-up. Only releases that meet the highlighting criteria (first release,
+major version bump, or explicitly flagged in the issue) get promoted to a
+top-level `##` section. Read the release notes to determine what treatment a
+release warrants. Routine releases with nothing interesting just go in the
+list.
 
 ### Issue Rotation
 


### PR DESCRIPTION
The lwip skill was putting most items as top-level ## sections with only Office Hours and Sync under Items of Note. Most content should live under Items of Note as ### subsections. Only a few categories warrant promotion to top-level ## sections: team membership changes, first releases (0.1.0), major version bumps, and items explicitly flagged for highlighting in the issue.

Updates both the lwip skill and CLAUDE.md to be consistent.