### PR TITLE
Add style/docstring-leading-blank to lint documentation

### DIFF
--- a/docs/use/linting.md
+++ b/docs/use/linting.md
@@ -47,6 +47,7 @@ corral run -- pony-lint src/ test/
 | `style/comment-spacing` | on | `//` not followed by exactly one space |
 | `style/control-structure-alignment` | on | Control structure keywords must be vertically aligned |
 | `style/docstring-format` | on | Docstring `"""` tokens should be on their own lines |
+| `style/docstring-leading-blank` | on | No blank line after opening `"""` |
 | `style/dot-spacing` | on | No spaces around `.`; `.>` spaced as infix operator |
 | `style/file-naming` | on | File name should match principal type |
 | `style/hard-tabs` | on | Tab characters anywhere in source |

--- a/docs/use/linting/rule-reference.md
+++ b/docs/use/linting/rule-reference.md
@@ -340,6 +340,31 @@ class Foo
     None
 ```
 
+## `style/docstring-leading-blank`
+
+**Default:** on
+
+The first line of docstring content must begin on the line immediately after the opening `"""` — no blank line in between. Types and methods annotated with `\nodoc\` are exempt, as are methods inside `\nodoc\`-annotated entities.
+
+**Incorrect:**
+
+```pony
+class Foo
+  """
+
+  Foo docstring.
+  """
+```
+
+**Correct:**
+
+```pony
+class Foo
+  """
+  Foo docstring.
+  """
+```
+
 ## `style/dot-spacing`
 
 **Default:** on


### PR DESCRIPTION
Adds documentation for the new `style/docstring-leading-blank` lint rule:
- New row in the rules table in `linting.md`
- New section with incorrect/correct examples in `rule-reference.md`

Companion to ponylang/ponyc#5122.