### PR TITLE
Fix Matthias spelling in embed-you-a-ponyc post

### DIFF
--- a/docs/blog/posts/embed-you-a-ponyc-for-great-good.md
+++ b/docs/blog/posts/embed-you-a-ponyc-for-great-good.md
@@ -30,7 +30,7 @@ What we wrote it in was Pony.
 
 libponyc-standalone is technically just the `.a`. The interesting part is what's on top of it. Call it the other half of libponyc-standalone: a Pony wrapper that gives you a real API to the compiler's internals.
 
-The wrapper is Mathias's pony-ast. I'd started something similar years ago and never got it over the line. His was better.
+The wrapper is Matthias's pony-ast. I'd started something similar years ago and never got it over the line. His was better.
 
 It lives in the ponyc repo at [`tools/lib/ponylang/pony_compiler/`](https://github.com/ponylang/ponyc/tree/main/tools/lib/ponylang/pony_compiler). The basic shape looks like this:
 


### PR DESCRIPTION
The contributor's name is Matthias Wahl (double-t), per his GitHub identity. The original post had it as "Mathias" (single-t). Fixing.

A second instance of the same typo exists in `docs/blog/posts/last-week-in-pony-063024.md:11` ("Mathias has released..."). It refers to the same person but is in a published weekly archive — left as-is here pending a separate call on whether to retroactively edit historical LWIP posts.